### PR TITLE
Revamp of Read Tests to Better Reflect Spark/Cassandra Intersection

### DIFF
--- a/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
+++ b/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
@@ -38,7 +38,9 @@ object SparkCassandraStress {
 
       arg[String]("testName") optional() action { (arg,config) =>
         config.copy(testName = arg.toLowerCase())
-      } text {"Name of the test to be run: "+VALID_TESTS.mkString(" , ")}
+      } text {  s"""Tests :
+              |Write Tests:  ${WriteTask.ValidTasks.mkString(" , ")}
+              |Read Tests: ${ReadTask.ValidTasks.mkString(" , ")}""".stripMargin}
 
       opt[String]('S', "save") optional() action { (arg,config) =>
         config.copy(file = Option(new FileWriter(arg, true)))
@@ -92,7 +94,10 @@ object SparkCassandraStress {
       
       
       help("help") text {"CLI Help"}
-      checkConfig{ c => if (VALID_TESTS.contains(c.testName)) success else failure(c.testName+" is not a valid test : "+VALID_TESTS.mkString(" , ")) }
+      checkConfig{ c => if (VALID_TESTS.contains(c.testName)) success else failure(
+        s"""${c.testName} is not a valid test :
+           |Write Tests:  ${WriteTask.ValidTasks.mkString(" , ")}
+           |Read Tests: ${ReadTask.ValidTasks.mkString(" , ")}""".stripMargin)}
     }
 
     parser.parse(args, Config()) map { config =>
@@ -132,15 +137,15 @@ object SparkCassandraStress {
         case "writeperfrow" => new WritePerfRow(config, sc)
         case "writerandomwiderow" => new WriteRandomWideRow(config, sc)
         case "writewiderowbypartition" => new WriteWideRowByPartition(config, sc)
-        case "countall" => new CountAll(config, sc)
-        case "aggregatecolor" => new AggregateColor(config, sc)
-        case "aggregatecolorsize" => new AggregateColorSize(config, sc)
-        case "filtercolorstringmatchcount" => new FilterColorStringMatchCount(config, sc)
-        case "filterequalityqtycolorsizecount" => new FilterEqualityQtyColorSizeCount(config, sc)
-        case "filterequalityqtycolorsizecountfivecols" => new FilterEqualityQtyColorSizeCountFiveCols(config, sc)
-        case "filterlessthanqtyequalitycolorsizecount" => new FilterLessThanQtyEqualityColorSizeCount(config, sc)
-        case "filterlessthanqtyequalitycolorsizefivecols" => new FilterLessThanQtyEqualityColorSizeCountFiveCols(config, sc)
-        case "filterqtymatchcount" => new FilterQtyMatchCount(config, sc)
+        case "pdcount" => new PDCount(config, sc)
+        case "ftsallcolumns" => new FTSAllColumns(config, sc)
+        case "ftsfivecolumns" => new FTSFiveColumns(config, sc)
+        case "ftsonecolumn" => new FTSOneColumn(config, sc)
+        case "ftspdclusteringallcolumns" => new FTSPDClusteringAllColumns(config, sc)
+        case "ftspdclusteringfivecolumns" => new FTSPDClusteringFiveColumns(config, sc)
+        case "jwcallcolumns" => new JWCAllColumns(config, sc)
+        case "jwcpdclusteringallcolumns" => new JWCPDClusteringAllColumns(config, sc)
+        case "jwcrpallcolumns" => new JWCRPAllColumns(config, sc)
         case "retrievesinglepartition" => new RetrieveSinglePartition(config, sc)
       }
 

--- a/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
@@ -32,7 +32,7 @@ class ReadTaskTests extends FlatSpec
     conn.withSessionDo { session =>
       session.execute(
         s"""
-           |CREATE KEYSPACE readperfks WITH
+           |CREATE KEYSPACE IF NOT EXISTS readperfks WITH
            |REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 } """
           .stripMargin)}
 
@@ -41,40 +41,40 @@ class ReadTaskTests extends FlatSpec
     writer.run
   }
 
-  "AggregateColor" should " be able to run" in {
-    new AggregateColor(config, sc).run
+  "FTSOneColumn" should " be able to run" in {
+    new FTSOneColumn(config, sc).run
   }
 
-  "AggregateColorSize" should " be able to run" in {
-    new AggregateColorSize(config, sc).run
+  "FTSAllColumns" should " be able to run" in {
+    new FTSAllColumns(config, sc).run
   }
 
-  "CountAll" should " be able to run" in {
-    new CountAll(config, sc).run
+  "PDCount" should " be able to run" in {
+    new PDCount(config, sc).run
   }
 
-  "FilterColorStringMatchCount" should " be able to run " in {
-    new FilterColorStringMatchCount(config, sc).run
+  "FTSFiveColumns" should " be able to run " in {
+    new FTSFiveColumns(config, sc).run
   }
 
-  "FilterEqualityQtyColorSizeCount" should " be able to run" in {
-    new FilterEqualityQtyColorSizeCount(config, sc).run
+  "FTSPDClusteringAllColumns" should " be able to run" in {
+    new FTSPDClusteringAllColumns(config, sc).run
   }
 
-  "FilterEqualityQtyColorSizeCountFiveCols" should " be able to run" in {
-    new FilterEqualityQtyColorSizeCountFiveCols(config, sc).run
+  "FTSPDClusteringFiveColumns" should " be able to run" in {
+    new FTSPDClusteringFiveColumns(config, sc).run
   }
 
-  "FilterLessThanQtyEqualityColorSizeCount" should " be able to run" in {
-    new FilterLessThanQtyEqualityColorSizeCount(config, sc).run
+  "JWCAllColumns" should " be able to run" in {
+    new JWCAllColumns(config, sc).run
   }
 
-  "FilterLessThanQtyequalityColorSizeCountFiveCols" should " be able to run " in {
-    new FilterLessThanQtyEqualityColorSizeCountFiveCols(config, sc).run
+  "JWCRPAllColumns" should " be able to run " in {
+    new JWCRPAllColumns(config, sc).run
   }
 
-  "FilterQtyMatchCount" should " be able to run " in {
-    new FilterQtyMatchCount(config, sc).run
+  "JWCPDClusteringAllColumns" should " be able to run " in {
+    new JWCPDClusteringAllColumns(config, sc).run
   }
 
   "RetrieveSinglePartiton" should " be able to run " in {


### PR DESCRIPTION
I've rewritten the read tests to try to focus more on the actual read
activity from C\* and less on underlying spark actions
(max/filter/reduce/group). The new tests are focused on testing the
performance of:
FullTableScans : FTS tests
Pushdown of Clustering Keys: PDClustering tests
JoinWithCassandra: JWC Tests
