### PR TITLE
Allow compiling against 4.7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ def deps = [
                     'hadoop',
                     'hadoop/lib',
             ].each { dir ->
+
                 provided fileTree(dir: "$DseResources/$dir", include: '*.jar')
             }
 
@@ -42,6 +43,12 @@ def deps = [
             ].each { dir ->
                 provided fileTree(dir: "$DseHome/$dir", include: '*.jar')
             }
+
+            def connector = fileTree(dir: "$DseResources/spark/lib", include: '*connector_*.jar')
+            def connectorJarName = (connector as List)[0].name
+            def match = connectorJarName =~ /connector_.*-(.*)\.jar/
+            assert match.find(), "Unable to find Spark Cassandra Connector"
+            ConnectorVersion = match.group(1)
         },
         maven : {
             println "Using Maven Libraries"
@@ -127,6 +134,16 @@ sourceSets {
             } else {
                 srcDirs += 'src/apache'
             }
+
+            //Api Change Catcher -- This is done to catch the CassandraCount Change in connector 1.2.4
+            def (major, minor, patch) = ConnectorVersion.split(/\./,3).collect { Integer.parseInt(it) }
+            if (major == 1 && minor == 2 && patch < 4){
+                println("using special 1.2.0 -1.2.3 code")
+                srcDirs += 'src/connector/1.2.0to1.2.3'
+            } else if (major == 1 && minor <= 1 ) {
+                srcDirs += 'src/connector/lessThan1.2.0'
+            } else { srcDirs += 'src/connector/default' }
+
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,8 @@ def DseResources = System.env.DSE_RESOURCES ?: "$Home/dse/resources/"
 def mainClassName = "com.datastax.sparkstress.SparkCassandraStress"
 
 // Parameters for buliding against Maven Libs
-def ConnectorVersion = System.env.CONNECTOR_VERSION ?: '1.3.0'
-def SparkVersion = System.env.SPARK_VERSION ?: '1.3.1'
+def ConnectorVersion = System.env.CONNECTOR_VERSION ?: '1.4.0-M3'
+def SparkVersion = System.env.SPARK_VERSION ?: '1.4.1'
 
 // Parameter for building against Connector Repository
 def SparkCCHome = System.env.SPARKCC_HOME ?:
@@ -46,8 +46,9 @@ def deps = [
 
             def connector = fileTree(dir: "$DseResources/spark/lib", include: '*connector_*.jar')
             def connectorJarName = (connector as List)[0].name
-            def match = connectorJarName =~ /connector_.*-(.*)\.jar/
+            def match = connectorJarName =~ /connector_.*-(.*?)-?.*\.jar/
             assert match.find(), "Unable to find Spark Cassandra Connector"
+            println("Connector Version = " + match.group(1))
             ConnectorVersion = match.group(1)
         },
         maven : {
@@ -136,11 +137,12 @@ sourceSets {
             }
 
             //Api Change Catcher -- This is done to catch the CassandraCount Change in connector 1.2.4
-            def (major, minor, patch) = ConnectorVersion.split(/\./,3).collect { Integer.parseInt(it) }
+            def (major, minor, patch) = ConnectorVersion.split(/\./,3).collect { (it.find(/^\d+/).toInteger()) }
             if (major == 1 && minor == 2 && patch < 4){
-                println("using special 1.2.0 -1.2.3 code")
+                println("using special 1.2.0 -1.2.3 stubs")
                 srcDirs += 'src/connector/1.2.0to1.2.3'
-            } else if (major == 1 && minor <= 1 ) {
+            } else if (major <= 1 && minor <= 1 ) {
+                println("using pre-Connector 1.2.0 stubs")
                 srcDirs += 'src/connector/lessThan1.2.0'
             } else { srcDirs += 'src/connector/default' }
 

--- a/src/connector/1.2.0to1.2.3/com/datastax/sparkstress/SparkStressImplicits.scala
+++ b/src/connector/1.2.0to1.2.3/com/datastax/sparkstress/SparkStressImplicits.scala
@@ -1,0 +1,18 @@
+package com.datastax.sparkstress
+
+import com.datastax.spark.connector.rdd.{CassandraTableScanRDD, CassandraRDD}
+
+/* In these version of the connector cassandraCount did not exist and was invoked
+by calling .count */
+object SparkStressImplicits {
+
+  implicit def toCassandraCountable[T](rdd: CassandraTableScanRDD[T]): CassandraCountable[T] =
+    new CassandraCountable(rdd)
+}
+
+class CassandraCountable[T](rdd: CassandraTableScanRDD[T]) {
+
+  def cassandraCount(): Long = {
+    rdd.count()
+  }
+}

--- a/src/connector/default/com/datastax/sparkstress/SparkStressImplicits.scala
+++ b/src/connector/default/com/datastax/sparkstress/SparkStressImplicits.scala
@@ -1,4 +1,5 @@
 package com.datastax.sparkstress
 
 object SparkStressImplicits {
+
 }

--- a/src/connector/default/com/datastax/sparkstress/SparkStressImplicits.scala
+++ b/src/connector/default/com/datastax/sparkstress/SparkStressImplicits.scala
@@ -1,0 +1,4 @@
+package com.datastax.sparkstress
+
+object SparkStressImplicits {
+}

--- a/src/connector/lessThan1.2.0/com/datastax/sparkstress/SparkStressImplicits.scala
+++ b/src/connector/lessThan1.2.0/com/datastax/sparkstress/SparkStressImplicits.scala
@@ -2,21 +2,26 @@ package com.datastax.sparkstress
 
 import java.nio.file.Path
 
-import com.datastax.bdp.spark.writer.BulkWriteConf
+import com.datastax.spark.connector.cql.CassandraConnector
+import com.datastax.spark.connector.rdd.CassandraRDD
+import com.datastax.spark.connector.writer.{RowWriterFactory, WriteConf}
 import com.datastax.spark.connector.{AllColumns, ColumnSelector}
-import com.datastax.spark.connector.rdd.{CassandraTableScanRDD, CassandraRDD}
 import org.apache.spark.rdd.RDD
 
 /* In these version of the connector cassandraCount did not exist and was invoked
 by calling .count */
 object SparkStressImplicits {
 
-  implicit def toCassandraCountable[T](rdd: CassandraTableScanRDD[T]): CassandraCountable[T] =
-    new CassandraCountable(rdd)
+  implicit def toNotAvailaibleFunctions[T](rdd: RDD[T]): NotAvailableFunctions[T] =
+    new NotAvailableFunctions(rdd)
 
   implicit def toBulkTableWriter[T](rdd: RDD[T]): BulkTableWriter[T] =
     new BulkTableWriter(rdd)
 }
+
+case class BulkWriteConf(outputDirectory: Option[Path] = None,
+                         deleteSource: Boolean = true,
+                         bufferSizeInMB: Int = 64)
 
 class BulkTableWriter[T](rdd: RDD[T]) {
 
@@ -28,13 +33,23 @@ class BulkTableWriter[T](rdd: RDD[T]) {
   }
 }
 
-case class BulkWriteConf(outputDirectory: Option[Path] = None,
-                         deleteSource: Boolean = true,
-                         bufferSizeInMB: Int = 64)
 
-class CassandraCountable[T](rdd: CassandraTableScanRDD[T]) {
+class NotAvailableFunctions[T](rdd: RDD[T]) {
 
   def cassandraCount(): Long = {
     throw new UnsupportedOperationException("There are no push down Cassandra counts in Connector < 1.2")
   }
+
+  def joinWithCassandraTable[K](args: Any*):CassandraRDD[(T,K)] = {
+    throw new UnsupportedOperationException("Join With Cassandra Table doesn't exist in Connector < 1.2")
+  }
+
+  def repartitionByCassandraReplica(args: Any*): CassandraRDD[T] = {
+    throw new UnsupportedOperationException("Repartition by Cassandra Table Doesn't exist in Connector < 1.2")
+  }
+
+  def spanBy[K](args: Any*):RDD[K] = {
+    throw new UnsupportedOperationException("SpanBy Doesn't exist in the connector < 1.2")
+  }
+
 }

--- a/src/connector/lessThan1.2.0/com/datastax/sparkstress/SparkStressImplicits.scala
+++ b/src/connector/lessThan1.2.0/com/datastax/sparkstress/SparkStressImplicits.scala
@@ -1,6 +1,11 @@
 package com.datastax.sparkstress
 
+import java.nio.file.Path
+
+import com.datastax.bdp.spark.writer.BulkWriteConf
+import com.datastax.spark.connector.{AllColumns, ColumnSelector}
 import com.datastax.spark.connector.rdd.{CassandraTableScanRDD, CassandraRDD}
+import org.apache.spark.rdd.RDD
 
 /* In these version of the connector cassandraCount did not exist and was invoked
 by calling .count */
@@ -8,7 +13,24 @@ object SparkStressImplicits {
 
   implicit def toCassandraCountable[T](rdd: CassandraTableScanRDD[T]): CassandraCountable[T] =
     new CassandraCountable(rdd)
+
+  implicit def toBulkTableWriter[T](rdd: RDD[T]): BulkTableWriter[T] =
+    new BulkTableWriter(rdd)
 }
+
+class BulkTableWriter[T](rdd: RDD[T]) {
+
+  def bulkSaveToCassandra(keyspaceName: String,
+                          tableName: String,
+                          columns: ColumnSelector = AllColumns,
+                          writeConf: BulkWriteConf = BulkWriteConf()): Unit = {
+    throw new UnsupportedOperationException
+  }
+}
+
+case class BulkWriteConf(outputDirectory: Option[Path] = None,
+                         deleteSource: Boolean = true,
+                         bufferSizeInMB: Int = 64)
 
 class CassandraCountable[T](rdd: CassandraTableScanRDD[T]) {
 

--- a/src/connector/lessThan1.2.0/com/datastax/sparkstress/SparkStressImplicits.scala
+++ b/src/connector/lessThan1.2.0/com/datastax/sparkstress/SparkStressImplicits.scala
@@ -1,0 +1,18 @@
+package com.datastax.sparkstress
+
+import com.datastax.spark.connector.rdd.{CassandraTableScanRDD, CassandraRDD}
+
+/* In these version of the connector cassandraCount did not exist and was invoked
+by calling .count */
+object SparkStressImplicits {
+
+  implicit def toCassandraCountable[T](rdd: CassandraTableScanRDD[T]): CassandraCountable[T] =
+    new CassandraCountable(rdd)
+}
+
+class CassandraCountable[T](rdd: CassandraTableScanRDD[T]) {
+
+  def cassandraCount(): Long = {
+    throw new UnsupportedOperationException("There are no push down Cassandra counts in Connector < 1.2")
+  }
+}

--- a/src/main/scala/com/datastax/sparkstress/ReadTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/ReadTask.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import com.datastax.sparkstress.RowTypes.PerfRowClass
 import org.apache.spark.SparkContext
 import com.datastax.spark.connector._
+import com.datastax.sparkstress.SparkStressImplicits._
 import org.joda.time.DateTime
 
 object ReadTask {

--- a/src/main/scala/com/datastax/sparkstress/WriteTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/WriteTask.scala
@@ -6,6 +6,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.SparkContext
 import com.datastax.sparkstress.RowTypes._
 import com.datastax.spark.connector._
+import com.datastax.spark.connector.RDDFunctions
 import com.datastax.bdp.spark.writer.BulkTableWriter._
 
 object WriteTask {
@@ -49,7 +50,8 @@ abstract class WriteTask[rowType](
   def run() = {
     config.saveMethod match {
       case "bulk" => getRDD.bulkSaveToCassandra(config.keyspace, config.table)
-      case _ => getRDD.saveToCassandra(config.keyspace, config.table)
+      case _ => new RDDFunctions(getRDD).saveToCassandra(config.keyspace, config.table)
+      //For Some reason the implicit doesn't work here in Connector 1.[1,0].X
   	}
   }
 

--- a/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
@@ -105,7 +105,7 @@ class WriteTaskTests extends FlatSpec
       totalOps = 40,
       numTotalKeys = 4)
     val writer = new WritePerfRow(config, sc)
-    val rowLengths = writer.getRDD.spanBy( u=> u.store).map(row => row._2).collect()
+    val rowLengths = writer.getRDD.groupBy( u=> u.store).map(row => row._2).collect
     for (row <- rowLengths)
       row should have size 10
   }


### PR DESCRIPTION
Here we add in hooks so that we can add implicits based on version to
shade various tests. CassandraCount only exists after 1.2.4 because
prior to this it was the default behavior for all counts in 1.2.0. The
functionality doesn't exist at all in versions before that so we throw
an error if the function is attempted to be called.
