### PR TITLE
DSP-10262: Added timebox for write and streaming workloads.

### DIFF
--- a/src/main/scala/com/datastax/sparkstress/ReadTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/ReadTask.scala
@@ -37,10 +37,10 @@ abstract class ReadTask(config: Config, sc: SparkContext) extends StressTask {
 
   def run()
 
-  def runTrials(sc: SparkContext): Seq[Long] = {
+  def runTrials(sc: SparkContext): Seq[TestResult] = {
     println("About to Start Trials")
     for (trial <- 1 to config.trials) yield {
-      time(run())
+      TestResult(time(run()),0L)
     }
   }
 }

--- a/src/main/scala/com/datastax/sparkstress/StressReceiver.scala
+++ b/src/main/scala/com/datastax/sparkstress/StressReceiver.scala
@@ -39,6 +39,6 @@ class StressReceiver[T](
 
 
 
- def onStop() = {
+  def onStop() = {
   }
 }

--- a/src/main/scala/com/datastax/sparkstress/StressTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/StressTask.scala
@@ -3,7 +3,7 @@ package com.datastax.sparkstress
 import org.apache.spark.SparkContext
 
 trait StressTask {
-    def runTrials(sc:SparkContext): Seq[Long]
+    def runTrials(sc:SparkContext): Seq[TestResult]
 
     def time(f: => Any): (Long) = {
       val t0 = System.nanoTime()

--- a/src/main/scala/org/apache/spark/ExposeJobListener.scala
+++ b/src/main/scala/org/apache/spark/ExposeJobListener.scala
@@ -1,0 +1,9 @@
+package org.apache.spark
+import org.apache.spark.ui.jobs.JobProgressListener
+
+object ExposeJobListener {
+  def getjobListener(sparkContext: SparkContext): JobProgressListener = {
+    sparkContext.jobProgressListener
+  }
+}
+


### PR DESCRIPTION
Added a timebox for running write and streaming workloads. If the test finishes before the specified time limit the test exits and reports the runtime and opsPerSec as before. If the timeout was exceeded, then the test is interrupted and the test reports the adjusted runtime and opsPerSec. I did not add this feature for read tests because I could not find a clean way of interrupting a `sc.cassandraTable[T](k,t).count()` operation which most of our read tests do, I'm open to ideas here for a follow-up PR.

When interrupting a write test one may see the following warnings.

```
WARN  2016-07-05 19:39:09,193 com.sun.jersey.spi.inject.Errors: The following warnings have been detected with resource and/or provider classes:
WARNING: A sub-resource method, public scala.collection.Seq org.apache.spark.status.api.v1.OneStageResource.stageData(int), with URI template, "", is treated as a resource method
...
ERROR 2016-07-05 19:39:11,002 org.apache.spark.scheduler.LiveListenerBus: SparkListenerBus has already stopped! Dropping event SparkListenerStageCompleted(org.apache.spark.scheduler.StageInfo@10d18696)
ERROR 2016-07-05 19:39:11,002 org.apache.spark.scheduler.LiveListenerBus: SparkListenerBus has already stopped! Dropping event SparkListenerJobEnd(0,1467772751002,JobFailed(org.apache.spark.SparkException: Job 0 cancelled because SparkContext was shut down))
```

When interrupting the streaming test one may see the following warnings/errors (as before). I haven't found a good way around these yet.

```
ERROR 2016-07-05 19:43:15,860 org.apache.spark.streaming.scheduler.ReceiverTracker: Deregistered receiver for stream 0: Stopped by driver
ERROR 2016-07-05 19:43:16,687 org.apache.spark.scheduler.TaskSchedulerImpl: Lost executor 0 on 10.150.0.36: Remote RPC client disassociated. Likely due to containers exceeding thresholds, or network issues. Check driver logs for WARN messages.
WARN  2016-07-05 19:43:16,692 org.apache.spark.scheduler.TaskSetManager: Lost task 0.0 in stage 13.0 (TID 315, 10.150.0.36): ExecutorLostFailure (executor 0 exited caused by one of the running tasks) Reason: Remote RPC client disassociated. Likely due to containers exceeding thresholds, or network issues. Check driver logs for WARN messages.
...
WARN  2016-07-05 19:43:19,980 org.apache.spark.scheduler.TaskSetManager: Lost task 5.1 in stage 15.0 (TID 348, 10.150.0.36): java.lang.Exception: Could not compute split, block input-0-1467772990800 not found
```

Follow-up work:
0. Extend the timebox feature for read tests.
1. Generalize the timebox to accept different units such as hours or days.
2. Extend the timebox feature to multiple trials.
3. Find a way to gracefully interrupt the tests without polluting the output.
