### PR TITLE
Fix spark master setting when it's not provided the user.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -12,14 +12,14 @@ if [ $startConnIdx -eq $# ]; then
   stressArgs=${*:2}
 else 
   connectorArgs=${*:$((startConnIdx))} 
-  sparkmaster=${*:$((startConnIdx-1)):1}
+  sparkmaster="--master ${*:$((startConnIdx-1)):1}"
   stressArgs=${*:2:$((startConnIdx-2))}
 fi
 
 JAR=build/libs/SparkCassandraStress-1.0.jar
 CLASS=com.datastax.sparkstress.SparkCassandraStress
 
-SUBMIT="spark-submit --master $sparkmaster $connectorArgs --class $CLASS $JAR $stressArgs"
+SUBMIT="spark-submit $sparkmaster $connectorArgs --class $CLASS $JAR $stressArgs"
 
 if [[ $1 == "dse" ]]; then
   dse $SUBMIT 


### PR DESCRIPTION
If the user does not provide a sparkmaster param the previous setup will fail to run. This fixes that.
