### PR TITLE
Generalize spark cassandra connector matching logic.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ ext.mainClassName = "com.datastax.sparkstress.SparkCassandraStress"
 
 def determineConnectorVersion() {
     if (against == 'dse') {
-        def connector = fileTree(dir: "$DseResources/spark/lib", include: '*connector_*.jar')
+        def connector = fileTree(dir: "$DseResources/spark/lib", include: 'spark*connector*_*.jar')
         def connectorJarName = (connector as List)[0].name
-        def match = connectorJarName =~ /connector_.*-(\d+\.\d+.\d+).*\.jar/
+        def match = connectorJarName =~ /connector.*_.*-(\d+\.\d+.\d+).*\.jar/
         assert match.find(), "Unable to find Spark Cassandra Connector"
         assert match.group(1).length() != 0, "Unable to determine version from " + match.group(0)
         println("Connector Version = " + match.group(1))


### PR DESCRIPTION
I generalized the logic for matching the spark cassandra connector to handle cases when the connector file name may change during active development. As an example DSE 5.0.4 is using `spark-cassandra-connector-unshaded_2.10-1.6.2.jar` at the moment.