### PR TITLE
DSP-12676: Added Dataset API usage for reads and writes to DSE and DSEFS.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,6 +135,10 @@ dependencies {
     testCompile "org.scala-lang:scala-library:2.10.5"
     testCompile "com.datastax.spark:spark-cassandra-connector-embedded_2.10:1.2.1"
     testCompile "org.scalatest:scalatest_2.10:2.2.4"
+    compile("org.reflections:reflections:0.9.11") {
+        exclude group: 'dom4j', module: 'dom4j'
+        exclude group: 'org.javassist', module: 'javassist'
+    }
     compile "com.github.scopt:scopt_2.10:3.2.0"
     compile "joda-time:joda-time:2.8.1"
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ ext.mainClassName = "com.datastax.sparkstress.SparkCassandraStress"
 
 def determineConnectorVersion() {
     if (against == 'dse') {
-        def connector = fileTree(dir: "$DseResources/spark/lib", include: 'spark*connector*_*.jar')
+        def connector = fileTree(dir: "$DseResources/spark/lib", include: 'spark*connector*jar')
         def connectorJarName = (connector as List)[0].name
-        def match = connectorJarName =~ /connector.*_.*-(\d+\.\d+.\d+).*\.jar/
+        def match = connectorJarName =~ /.*(\d+\.\d+.\d+).*jar/
         assert match.find(), "Unable to find Spark Cassandra Connector"
         assert match.group(1).length() != 0, "Unable to determine version from " + match.group(0)
         println("Connector Version = " + match.group(1))

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def determineConnectorVersion() {
     if (against == 'dse') {
         def connector = fileTree(dir: "$DseResources/spark/lib", include: 'spark*connector*jar')
         def connectorJarName = (connector as List)[0].name
-        def match = connectorJarName =~ /.*(\d+\.\d+.\d+).*jar/
+        def match = connectorJarName =~ /.*-(\d+\.\d+.\d+).*jar/
         assert match.find(), "Unable to find Spark Cassandra Connector"
         assert match.group(1).length() != 0, "Unable to determine version from " + match.group(0)
         println("Connector Version = " + match.group(1))

--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,7 @@ dependencies deps[(against)]
 sourceSets {
     main {
         scala {
-            srcDirs = ['src/main/scala']
+            srcDirs = ['src/main/scala', 'src/main/java']
             if (against == 'dse') {
                 srcDirs += 'src/dse'
             } else {

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def determineConnectorVersion() {
     if (against == 'dse') {
         def connector = fileTree(dir: "$DseResources/spark/lib", include: 'spark*connector*jar')
         def connectorJarName = (connector as List)[0].name
-        def match = connectorJarName =~ /spark-cassandra-connector.*(\d+.\d+.\d).*jar/
+        def match = connectorJarName =~ /spark.*?connector.*?([\d.]+)\.jar/
         assert match.find(), "Unable to find Spark Cassandra Connector"
         assert match.group(1).length() != 0, "Unable to determine version from " + match.group(0)
         println("Connector Version = " + match.group(1))

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ def determineConnectorVersion() {
     if (against == 'dse') {
         def connector = fileTree(dir: "$DseResources/spark/lib", include: 'spark*connector*jar')
         def connectorJarName = (connector as List)[0].name
-        def match = connectorJarName =~ /.*-(\d+\.\d+.\d+).*jar/
+        def match = connectorJarName =~ /spark-cassandra-connector.*(\d+.\d+.\d).*jar/
         assert match.find(), "Unable to find Spark Cassandra Connector"
         assert match.group(1).length() != 0, "Unable to determine version from " + match.group(0)
         println("Connector Version = " + match.group(1))

--- a/run.sh
+++ b/run.sh
@@ -38,6 +38,7 @@ CLASS=com.datastax.sparkstress.SparkCassandraStress
 SUBMIT="spark-submit $sparkmaster $connectorArgs --class $CLASS $JAR $stressArgs"
 
 if [[ $1 == "dse" ]]; then
+  echo dse $SUBMIT 
   dse $SUBMIT 
 elif [[ $1 == "apache" ]]; then
   $SPARK_HOME/bin/$SUBMIT 

--- a/run.sh
+++ b/run.sh
@@ -38,8 +38,7 @@ CLASS=com.datastax.sparkstress.SparkCassandraStress
 SUBMIT="spark-submit $sparkmaster $connectorArgs --class $CLASS $JAR $stressArgs"
 
 if [[ $1 == "dse" ]]; then
-  echo dse $SUBMIT 
-  dse $SUBMIT 
+  dse $SUBMIT
 elif [[ $1 == "apache" ]]; then
   $SPARK_HOME/bin/$SUBMIT 
 else

--- a/src/apache/scala/com/datastax/sparkstress/ContextHelper.scala
+++ b/src/apache/scala/com/datastax/sparkstress/ContextHelper.scala
@@ -1,6 +1,7 @@
 package com.datastax.sparkstress
 
 import org.apache.spark.{SparkContext, SparkConf}
+import org.apache.spark.sql.SparkSession
 
 object ConnectHelper {
 
@@ -8,5 +9,11 @@ object ConnectHelper {
   Get a normal SparkContext Object
    */
   def getContext(conf: SparkConf): SparkContext =
-    new SparkContext(conf)
+    this.getSparkSession(conf).sparkContext
+
+  /*
+  Get a SparkSession Object
+ */
+  def getSparkSession(conf: SparkConf): SparkSession =
+    SparkSession.builder().config(conf).getOrCreate()
 }

--- a/src/apache/scala/com/datastax/sparkstress/ContextHelper.scala
+++ b/src/apache/scala/com/datastax/sparkstress/ContextHelper.scala
@@ -1,6 +1,7 @@
 package com.datastax.sparkstress
 
 import org.apache.spark.{SparkContext, SparkConf}
+import org.apache.spark.sql.SparkSession
 
 object ConnectHelper {
 
@@ -8,5 +9,11 @@ object ConnectHelper {
   Get a normal SparkContext Object
    */
   def getContext(conf: SparkConf): SparkContext =
-    new SparkContext(conf)
+    this.getSparkSession(conf).sparkContext
+
+  /*
+  Get a normal SparkContext Object
+ */
+  def getSparkSession(conf: SparkConf): SparkSession =
+    SparkSession.builder().config(conf).getOrCreate()
 }

--- a/src/apache/scala/com/datastax/sparkstress/ContextHelper.scala
+++ b/src/apache/scala/com/datastax/sparkstress/ContextHelper.scala
@@ -12,7 +12,7 @@ object ConnectHelper {
     this.getSparkSession(conf).sparkContext
 
   /*
-  Get a SparkSession Object
+  Get a normal SparkContext Object
  */
   def getSparkSession(conf: SparkConf): SparkSession =
     SparkSession.builder().config(conf).getOrCreate()

--- a/src/dse/scala/com/datastax/sparkstress/ContextHelper.scala
+++ b/src/dse/scala/com/datastax/sparkstress/ContextHelper.scala
@@ -1,5 +1,6 @@
 package com.datastax.sparkstress
 
+import org.apache.spark.sql.SparkSession
 import org.apache.spark.{SparkContext, SparkConf}
 import com.datastax.bdp.spark.DseSparkConfHelper._
 
@@ -9,5 +10,8 @@ object ConnectHelper {
    * @param conf
    */
   def getContext(conf: SparkConf): SparkContext =
-    new SparkContext(conf.forDse)
+    this.getSparkSession(conf).sparkContext
+
+  def getSparkSession(conf: SparkConf): SparkSession =
+    SparkSession.builder().config(conf.forDse).getOrCreate()
 }

--- a/src/dse/scala/com/datastax/sparkstress/ContextHelper.scala
+++ b/src/dse/scala/com/datastax/sparkstress/ContextHelper.scala
@@ -13,5 +13,5 @@ object ConnectHelper {
     this.getSparkSession(conf).sparkContext
 
   def getSparkSession(conf: SparkConf): SparkSession =
-    SparkSession.builder().config(conf.forDse).getOrCreate()
+    SparkSession.builder().config(conf).getOrCreate()
 }

--- a/src/main/java/com/datastax/sparkstress/ReadTest.java
+++ b/src/main/java/com/datastax/sparkstress/ReadTest.java
@@ -1,0 +1,10 @@
+package com.datastax.sparkstress;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface ReadTest{}

--- a/src/main/java/com/datastax/sparkstress/StreamingTest.java
+++ b/src/main/java/com/datastax/sparkstress/StreamingTest.java
@@ -1,0 +1,10 @@
+package com.datastax.sparkstress;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface StreamingTest{}

--- a/src/main/java/com/datastax/sparkstress/WriteTest.java
+++ b/src/main/java/com/datastax/sparkstress/WriteTest.java
@@ -1,0 +1,10 @@
+package com.datastax.sparkstress;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.TYPE)
+public @interface WriteTest{}

--- a/src/main/scala/com/datastax/sparkstress/DataGenerator.scala
+++ b/src/main/scala/com/datastax/sparkstress/DataGenerator.scala
@@ -39,13 +39,7 @@ object RowGenerator {
 
   def getShortRowDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalRows: Long): org.apache.spark.sql.Dataset[ShortRowClass] = {
     import ss.implicits._
-    val opsPerPartition = numTotalRows / numPartitions
-
-    ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
-      case (index, n) => {
-        generateShortRowPartition(seed, index, opsPerPartition)
-      }
-    }.toDS()
+    getShortRowRDD(ss, seed, numPartitions, numTotalRows).toDS()
   }
 
   def generateWideRowByPartitionPartition(seed: Long, index: Int, numPartitions: Int, numTotalKeys: Long, numTotalOps: Long) = {
@@ -67,9 +61,7 @@ object RowGenerator {
 
   def getWideRowByPartitionDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[WideRowClass] = {
     import ss.implicits._
-
-    ss.sparkContext.parallelize(Seq[Int](), numPartitions)
-      .mapPartitionsWithIndex { case (index, n) => generateWideRowByPartitionPartition(seed, index, numPartitions, numTotalKeys, numTotalOps) }.toDS()
+    getWideRowByPartition(ss, seed, numPartitions, numTotalOps, numTotalKeys).toDS()
   }
 
   def generateWideRowPartition(seed: Long, index: Int, numTotalKeys: Long, opsPerPartition: Long) = {
@@ -93,14 +85,7 @@ object RowGenerator {
 
   def getWideRowDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[WideRowClass] = {
     import ss.implicits._
-
-    val opsPerPartition = numTotalOps /numPartitions
-
-    ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
-      case (index, n) => {
-        generateWideRowPartition(seed, index, numTotalKeys, opsPerPartition)
-      }
-    }.toDS()
+    getWideRowRdd(ss, seed, numPartitions, numTotalOps, numTotalKeys).toDS()
   }
 
   def generateRandomWideRowPartition(seed: Long, index: Int, numTotalKeys: Long, opsPerPartition: Long) = {
@@ -123,14 +108,7 @@ object RowGenerator {
 
   def getRandomWideRowDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[WideRowClass] = {
     import ss.implicits._
-
-    val opsPerPartition = numTotalOps / numPartitions
-
-    ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
-      case (index, n) => {
-        generateRandomWideRowPartition(seed, index, numTotalKeys, opsPerPartition)
-      }
-    }.toDS()
+    getRandomWideRow(ss, seed, numPartitions, numTotalOps, numTotalKeys).toDS()
   }
 
   /**

--- a/src/main/scala/com/datastax/sparkstress/DataGenerator.scala
+++ b/src/main/scala/com/datastax/sparkstress/DataGenerator.scala
@@ -11,46 +11,46 @@ import com.datastax.sparkstress.RowTypes._
 import org.joda.time.DateTime
 
 abstract class RowGenerator[T] extends Serializable{
-  def generatePartition(intdex: Int) : Iterator[T]
+  def generatePartition(seed: Long, index: Int) : Iterator[T]
 }
 
 object RowGenerator {
 
 
-  def generateShortRowPartition(index: Int, opsPerPartition: Long) = {
-    val r = new scala.util.Random(index * System.currentTimeMillis())
+  def generateShortRowPartition(seed: Long, index: Int, opsPerPartition: Long) = {
+    val r = new scala.util.Random(index * seed)
     val start = opsPerPartition*index
     (0L until opsPerPartition).map { i =>
       new ShortRowClass(i + start, r.nextString(20), r.nextString(20), r.nextString(20))
     }.iterator
   }
 
-  def getShortRowRDD(ss: SparkSession, numPartitions: Int, numTotalRows: Long):
+  def getShortRowRDD(ss: SparkSession, seed: Long, numPartitions: Int, numTotalRows: Long):
   RDD[ShortRowClass] = {
 
     val opsPerPartition = numTotalRows / numPartitions
 
     ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
       case (index, n) => {
-        generateShortRowPartition(index, opsPerPartition)
+        generateShortRowPartition(seed, index, opsPerPartition)
       }
     }
   }
 
-  def getShortRowDataset(ss: SparkSession, numPartitions: Int, numTotalRows: Long): org.apache.spark.sql.Dataset[ShortRowClass] = {
+  def getShortRowDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalRows: Long): org.apache.spark.sql.Dataset[ShortRowClass] = {
     import ss.implicits._
 
     val opsPerPartition = numTotalRows / numPartitions
 
     ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
       case (index, n) => {
-        generateShortRowPartition(index, opsPerPartition)
+        generateShortRowPartition(seed, index, opsPerPartition)
       }
     }.toDS()
   }
 
-  def generateWideRowByPartitionPartition(index: Int, numPartitions: Int, numTotalKeys: Long, numTotalOps: Long) = {
-    val r = new scala.util.Random(index * System.currentTimeMillis())
+  def generateWideRowByPartitionPartition(seed: Long, index: Int, numPartitions: Int, numTotalKeys: Long, numTotalOps: Long) = {
+    val r = new scala.util.Random(index * seed)
     val keysPerPartition = numTotalKeys / numPartitions
     val start = keysPerPartition * numPartitions
     val ckeysPerPkey = numTotalOps / numTotalKeys
@@ -59,77 +59,77 @@ object RowGenerator {
       new WideRowClass((start + pk), (ck).toString, r.nextString(20), r.nextString(20))
   }
 
-  def getWideRowByPartition(ss: SparkSession, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long):
+  def getWideRowByPartition(ss: SparkSession, seed: Long, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long):
   RDD[WideRowClass] = {
 
     ss.sparkContext.parallelize(Seq[Int](), numPartitions)
-      .mapPartitionsWithIndex { case (index, n) => generateWideRowByPartitionPartition(index, numPartitions, numTotalKeys, numTotalOps) }
+      .mapPartitionsWithIndex { case (index, n) => generateWideRowByPartitionPartition(seed, index, numPartitions, numTotalKeys, numTotalOps) }
   }
 
-  def getWideRowByPartitionDataset(ss: SparkSession, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[WideRowClass] = {
+  def getWideRowByPartitionDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[WideRowClass] = {
     import ss.implicits._
 
     ss.sparkContext.parallelize(Seq[Int](), numPartitions)
-      .mapPartitionsWithIndex { case (index, n) => generateWideRowByPartitionPartition(index, numPartitions, numTotalKeys, numTotalOps) }.toDS()
+      .mapPartitionsWithIndex { case (index, n) => generateWideRowByPartitionPartition(seed, index, numPartitions, numTotalKeys, numTotalOps) }.toDS()
   }
 
-  def generateWideRowPartition(index: Int, numTotalKeys: Long, opsPerPartition: Long) = {
-    val r = new scala.util.Random(index * System.currentTimeMillis())
+  def generateWideRowPartition(seed: Long, index: Int, numTotalKeys: Long, opsPerPartition: Long) = {
+    val r = new scala.util.Random(index * seed)
     val start = opsPerPartition*index:Long
     (0L until opsPerPartition).map { i =>
       new WideRowClass((i + start) % numTotalKeys, (i + start).toString, r.nextString(20), r.nextString(20))
     }.iterator
   }
 
-  def getWideRowRdd(ss: SparkSession, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long):
+  def getWideRowRdd(ss: SparkSession, seed: Long, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long):
   RDD[WideRowClass] = {
     val opsPerPartition = numTotalOps /numPartitions
 
      ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
       case (index, n) => {
-        generateWideRowPartition(index, numTotalKeys, opsPerPartition)
+        generateWideRowPartition(seed, index, numTotalKeys, opsPerPartition)
       }
     }
   }
 
-  def getWideRowDataset(ss: SparkSession, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[WideRowClass] = {
+  def getWideRowDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[WideRowClass] = {
     import ss.implicits._
 
     val opsPerPartition = numTotalOps /numPartitions
 
     ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
       case (index, n) => {
-        generateWideRowPartition(index, numTotalKeys, opsPerPartition)
+        generateWideRowPartition(seed, index, numTotalKeys, opsPerPartition)
       }
     }.toDS()
   }
 
-  def generateRandomWideRowPartition(index: Int, numTotalKeys: Long, opsPerPartition: Long) = {
-    val r = new scala.util.Random(index * System.currentTimeMillis())
+  def generateRandomWideRowPartition(seed: Long, index: Int, numTotalKeys: Long, opsPerPartition: Long) = {
+    val r = new scala.util.Random(index * seed)
     (0L until opsPerPartition).map { i =>
       new WideRowClass(math.abs(r.nextLong()) % numTotalKeys, r.nextInt.toString, r.nextString(20), r.nextString(20))
     }.iterator
   }
 
-  def getRandomWideRow(ss: SparkSession, numPartitions: Int, numTotalOps: Long, numTotalKeys:
+  def getRandomWideRow(ss: SparkSession, seed: Long, numPartitions: Int, numTotalOps: Long, numTotalKeys:
   Long): RDD[WideRowClass] = {
     val opsPerPartition = numTotalOps / numPartitions
 
     ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
       case (index, n) => {
-        generateRandomWideRowPartition(index, numTotalKeys, opsPerPartition)
+        generateRandomWideRowPartition(seed, index, numTotalKeys, opsPerPartition)
       }
     }
   }
 
-  def getRandomWideRowDataset(ss: SparkSession, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[WideRowClass] = {
+  def getRandomWideRowDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalOps: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[WideRowClass] = {
     import ss.implicits._
 
     val opsPerPartition = numTotalOps / numPartitions
 
     ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
       case (index, n) => {
-        generateRandomWideRowPartition(index, numTotalKeys, opsPerPartition)
+        generateRandomWideRowPartition(seed, index, numTotalKeys, opsPerPartition)
       }
     }.toDS()
   }
@@ -142,7 +142,6 @@ object RowGenerator {
   val sizes = List("P", "S", "M", "L", "XL", "XXL", "XXXL").view
   val qtys = (5 to 10000 by 5).view
   val perftime = new DateTime(2000,1,1,0,0,0,0)
-  val perfRandom = 42
 
   class PerfRowGenerator(numPartitions: Int, numTotalRows: Long, numTotalKeys: Long)
     extends RowGenerator[PerfRowClass]() {
@@ -150,9 +149,9 @@ object RowGenerator {
     val clusteringKeysPerPartitionKey = numTotalRows / numTotalKeys
     val partitionKeysPerSparkPartition = numTotalKeys / numPartitions
 
-    override def generatePartition(index: Int): Iterator[PerfRowClass] = {
+    override def generatePartition(seed: Long, index: Int): Iterator[PerfRowClass] = {
       val offset = partitionKeysPerSparkPartition * index;
-      val r = new scala.util.Random(index * perfRandom)
+      val r = new scala.util.Random(index * seed)
 
       for ( pk <- (1L to partitionKeysPerSparkPartition).iterator; ck <- (1L to clusteringKeysPerPartitionKey).iterator) yield {
         val color = colors(r.nextInt(colors.size))
@@ -166,25 +165,25 @@ object RowGenerator {
     }
   }
 
-  def getPerfRowRdd(ss: SparkSession, numPartitions: Int, numTotalRows: Long, numTotalKeys: Long): RDD[PerfRowClass] = {
+  def getPerfRowRdd(ss: SparkSession, seed: Long, numPartitions: Int, numTotalRows: Long, numTotalKeys: Long): RDD[PerfRowClass] = {
 
     val perfRowGenerator = new PerfRowGenerator(numPartitions, numTotalRows, numTotalKeys)
 
     ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
       case (index, n) => {
-        perfRowGenerator.generatePartition(index)
+        perfRowGenerator.generatePartition(seed, index)
       }
     }
   }
 
-  def getPerfRowDataset(ss: SparkSession, numPartitions: Int, numTotalRows: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[PerfRowClass] = {
+  def getPerfRowDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalRows: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[PerfRowClass] = {
     import ss.implicits._
 
     val perfRowGenerator = new PerfRowGenerator(numPartitions, numTotalRows, numTotalKeys)
 
     ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
       case (index, n) => {
-        perfRowGenerator.generatePartition(index)
+        perfRowGenerator.generatePartition(seed, index)
       }
     }.toDS()
   }

--- a/src/main/scala/com/datastax/sparkstress/DataGenerator.scala
+++ b/src/main/scala/com/datastax/sparkstress/DataGenerator.scala
@@ -175,14 +175,7 @@ object RowGenerator {
 
   def getPerfRowDataset(ss: SparkSession, seed: Long, numPartitions: Int, numTotalRows: Long, numTotalKeys: Long): org.apache.spark.sql.Dataset[PerfRowClass] = {
     import ss.implicits._
-
-    val perfRowGenerator = new PerfRowGenerator(numPartitions, numTotalRows, numTotalKeys)
-
-    ss.sparkContext.parallelize(Seq[Int](), numPartitions).mapPartitionsWithIndex {
-      case (index, n) => {
-        perfRowGenerator.generatePartition(seed, index)
-      }
-    }.toDS()
+    getPerfRowRdd(ss, seed, numPartitions, numTotalRows, numTotalKeys).toDS()
   }
 
 }

--- a/src/main/scala/com/datastax/sparkstress/ReadTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/ReadTask.scala
@@ -124,7 +124,7 @@ class PDCount(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
 
 /**
  * Full Table Scan One Column
- * Performs a full table scan but only retreives a single column from the underlying
+ * Performs a full table scan but only retrieves a single column from the underlying
  * table.
  */
 class FTSOneColumn(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
@@ -141,8 +141,7 @@ class FTSOneColumn(config: Config, ss: SparkSession) extends DatasetReadTask(con
 
 /**
  * Full Table Scan One Column
- * Performs a full table scan but only retreives a single column from the underlying
- * table.
+ * Performs a full table scan but only retrieves all columns from the underlying table.
  */
 class FTSAllColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
   def run(): Unit = {
@@ -157,7 +156,7 @@ class FTSAllColumns(config: Config, ss: SparkSession) extends DatasetReadTask(co
 
 /**
  * Full Table Scan Five Columns
- * Performs a full table scan and only retreives 5 of the columns for each row
+ * Performs a full table scan and only retrieves 5 of the columns for each row
  */
 class FTSFiveColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
   def run(): Unit = {
@@ -191,7 +190,7 @@ class FTSPDClusteringAllColumns(config: Config, ss: SparkSession) extends ReadTa
 
 /**
  * Full Table Scan with a Clustering Column Predicate Pushed down to C*
- * Only 5 columns retreived per row
+ * Only 5 columns retrieved per row
  */
 class FTSPDClusteringFiveColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = config.distributedDataType match {
@@ -222,7 +221,7 @@ class JWCAllColumns(config: Config, ss: SparkSession) extends ReadTask(config, s
 
 /**
  * Join With C* with 1M Partition Key requests
- * A repartitionByCassandraReplica occurs before retreiving the data
+ * A repartitionByCassandraReplica occurs before retrieving the data
  */
 class JWCRPAllColumns(config: Config, ss: SparkSession) extends
 ReadTask(config, ss) {
@@ -256,7 +255,7 @@ class JWCPDClusteringAllColumns(config: Config, ss: SparkSession) extends ReadTa
 }
 
 /**
- * A single C* partition is retreivied in an RDD
+ * A single C* partition is retrieved in an RDD
  */
 class RetrieveSinglePartition(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = config.saveMethod match {

--- a/src/main/scala/com/datastax/sparkstress/ReadTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/ReadTask.scala
@@ -9,27 +9,6 @@ import com.datastax.spark.connector._
 import com.datastax.sparkstress.SparkStressImplicits._
 import org.joda.time.DateTime
 
-object ReadTask {
-  val ValidTasks = Set(
-    "FTSAllColumns",
-    "FTSFiveColumns",
-    "FTSOneColumn",
-    "FTSPDClusteringAllColumns",
-    "FTSPDClusteringFiveColumns",
-    "JWCAllColumns",
-    "JWCPDClusteringAllColumns",
-    "JWCRPAllColumns",
-    "PDCount",
-    "FTSOneColumn_DS",
-    "FTSTwoColumns_DS",
-    "FTSThreeColumns_DS",
-    "FTSFourColumns_DS",
-    "FTSFiveColumns_DS",
-    "FTSAllColumns_DS",
-    "RetrieveSinglePartition"
-  )
-}
-
 abstract class ReadTask(config: Config, ss: SparkSession) extends StressTask {
 
   val sc = ss.sparkContext

--- a/src/main/scala/com/datastax/sparkstress/ReadTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/ReadTask.scala
@@ -79,7 +79,7 @@ class FTSOneColumn_DS(config: Config, ss: SparkSession) extends ReadTask(config,
 
 /**
   * Full Table Scan Two Columns using DataSets
-  * Performs a full table scan but only retrieves a single column from the underlying
+  * Performs a full table scan retrieving two columns from the underlying
   * table.
   */
 class FTSTwoColumns_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {

--- a/src/main/scala/com/datastax/sparkstress/ReadTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/ReadTask.scala
@@ -61,6 +61,7 @@ abstract class DatasetReadTask(config: Config, ss: SparkSession) extends ReadTas
   * Performs a full table scan retrieving two columns from the underlying
   * table.
   */
+@ReadTest
 class FTSTwoColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
   override def run(): Unit = {
     println("Loaded %d rows".format(
@@ -77,6 +78,7 @@ class FTSTwoColumns(config: Config, ss: SparkSession) extends DatasetReadTask(co
   * Performs a full table scan but only retrieves a single column from the underlying
   * table.
   */
+@ReadTest
 class FTSThreeColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
   override def run(): Unit = {
     println("Loaded %d rows".format(
@@ -93,6 +95,7 @@ class FTSThreeColumns(config: Config, ss: SparkSession) extends DatasetReadTask(
   * Performs a full table scan but only retrieves a single column from the underlying
   * table.
   */
+@ReadTest
 class FTSFourColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
   override def run(): Unit = {
     println("Loaded %d rows".format(
@@ -109,6 +112,7 @@ class FTSFourColumns(config: Config, ss: SparkSession) extends DatasetReadTask(c
  * Uses our internally cassandra count pushdown, this means all of the aggregation
  * is done on the C* side
  */
+@ReadTest
 class PDCount(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
 
   def run(): Unit = config.saveMethod match {
@@ -127,6 +131,7 @@ class PDCount(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
  * Performs a full table scan but only retrieves a single column from the underlying
  * table.
  */
+@ReadTest
 class FTSOneColumn(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
 
   def run(): Unit = {
@@ -143,6 +148,7 @@ class FTSOneColumn(config: Config, ss: SparkSession) extends DatasetReadTask(con
  * Full Table Scan One Column
  * Performs a full table scan but only retrieves all columns from the underlying table.
  */
+@ReadTest
 class FTSAllColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
   def run(): Unit = {
     println("Loaded %d rows".format(
@@ -158,6 +164,7 @@ class FTSAllColumns(config: Config, ss: SparkSession) extends DatasetReadTask(co
  * Full Table Scan Five Columns
  * Performs a full table scan and only retrieves 5 of the columns for each row
  */
+@ReadTest
 class FTSFiveColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
   def run(): Unit = {
     println("Loaded %d rows".format(
@@ -176,6 +183,7 @@ class FTSFiveColumns(config: Config, ss: SparkSession) extends DatasetReadTask(c
 /**
  * Full Table Scan with a Clustering Column Predicate Pushed down to C*
  */
+@ReadTest
 class FTSPDClusteringAllColumns(config: Config, ss: SparkSession) extends ReadTask(config,
   ss) {
   def run(): Unit = config.distributedDataType match {
@@ -192,6 +200,7 @@ class FTSPDClusteringAllColumns(config: Config, ss: SparkSession) extends ReadTa
  * Full Table Scan with a Clustering Column Predicate Pushed down to C*
  * Only 5 columns retrieved per row
  */
+@ReadTest
 class FTSPDClusteringFiveColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = config.distributedDataType match {
     case "rdd" =>
@@ -207,6 +216,7 @@ class FTSPDClusteringFiveColumns(config: Config, ss: SparkSession) extends ReadT
 /**
  * Join With C* with 1M Partition Key requests
  */
+@ReadTest
 class JWCAllColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = config.saveMethod match {
     case "rdd" =>
@@ -223,6 +233,7 @@ class JWCAllColumns(config: Config, ss: SparkSession) extends ReadTask(config, s
  * Join With C* with 1M Partition Key requests
  * A repartitionByCassandraReplica occurs before retrieving the data
  */
+@ReadTest
 class JWCRPAllColumns(config: Config, ss: SparkSession) extends
 ReadTask(config, ss) {
   def run(): Unit = config.saveMethod match {
@@ -241,6 +252,7 @@ ReadTask(config, ss) {
  * Join With C* with 1M Partition Key requests
  * A clustering column predicate is pushed down to limit data retrevial
  */
+@ReadTest
 class JWCPDClusteringAllColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = config.saveMethod match {
     case "rdd" =>
@@ -257,6 +269,7 @@ class JWCPDClusteringAllColumns(config: Config, ss: SparkSession) extends ReadTa
 /**
  * A single C* partition is retrieved in an RDD
  */
+@ReadTest
 class RetrieveSinglePartition(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = config.saveMethod match {
     case "rdd" =>
@@ -267,4 +280,3 @@ class RetrieveSinglePartition(config: Config, ss: SparkSession) extends ReadTask
     case _ => println("This test is not supported with the dataset API.")
   }
 }
-

--- a/src/main/scala/com/datastax/sparkstress/ReadTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/ReadTask.scala
@@ -62,10 +62,13 @@ abstract class DatasetReadTask(config: Config, ss: SparkSession) extends ReadTas
   * table.
   */
 class FTSTwoColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
-  override def run(): Unit = config.saveMethod match {
-    case "rdd" => val count = sc.cassandraTable[String](keyspace, table).select("color", "size").count
-    case _ => val count = read_columns(Seq("color", "size"))
-    println(s"Loaded $count rows")
+  override def run(): Unit = {
+    println("Loaded %d rows".format(
+      config.saveMethod match {
+        case "rdd" => sc.cassandraTable[String](keyspace, table).select("color", "size").count
+        case _ => read_columns(Seq("color", "size"))
+      })
+    )
   }
 }
 
@@ -75,10 +78,13 @@ class FTSTwoColumns(config: Config, ss: SparkSession) extends DatasetReadTask(co
   * table.
   */
 class FTSThreeColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
-  override def run(): Unit = config.saveMethod match {
-    case "rdd" => val count = sc.cassandraTable[String](keyspace, table).select("color", "size", "qty").count
-    case _ => val count = read_columns(Seq("color", "size", "qty"))
-    println(s"Loaded $count rows")
+  override def run(): Unit = {
+    println("Loaded %d rows".format(
+      config.saveMethod match {
+        case "rdd" => sc.cassandraTable[String](keyspace, table).select("color", "size", "qty").count
+        case _ => read_columns(Seq("color", "size", "qty"))
+      })
+    )
   }
 }
 
@@ -88,10 +94,13 @@ class FTSThreeColumns(config: Config, ss: SparkSession) extends DatasetReadTask(
   * table.
   */
 class FTSFourColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
-  override def run(): Unit = config.saveMethod match {
-    case "rdd" => val count = sc.cassandraTable[String](keyspace, table).select("color", "size", "qty", "order_number").count
-    case _ => val count = read_columns(Seq("color", "size", "qty", "order_number"))
-    println(s"Loaded $count rows")
+  override def run(): Unit = {
+    println("Loaded %d rows".format(
+      config.saveMethod match {
+        case "rdd" => sc.cassandraTable[String](keyspace, table).select("color", "size", "qty", "order_number").count
+        case _ => read_columns(Seq("color", "size", "qty", "order_number"))
+      })
+    )
   }
 }
 
@@ -120,10 +129,13 @@ class PDCount(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
  */
 class FTSOneColumn(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
 
-  def run(): Unit = config.saveMethod match {
-    case "rdd" => val count = sc.cassandraTable[String](keyspace, table).select("color").count
-    case _ => val count = read_columns(Seq("color"))
-    println(s"Loaded $count rows")
+  def run(): Unit = {
+    println("Loaded %d rows".format(
+      config.saveMethod match {
+        case "rdd" => sc.cassandraTable[String](keyspace, table).select("color").count
+        case _ => read_columns(Seq("color"))
+      })
+    )
   }
 }
 
@@ -133,10 +145,13 @@ class FTSOneColumn(config: Config, ss: SparkSession) extends DatasetReadTask(con
  * table.
  */
 class FTSAllColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
-  def run(): Unit = config.distributedDataType match {
-    case "rdd" => val count = sc.cassandraTable[PerfRowClass](keyspace, table).count
-    case _ => val count = read_columns(Seq("order_number", "qty", "color", "size", "order_time", "store"))
-    println(s"Loaded $count rows")
+  def run(): Unit = {
+    println("Loaded %d rows".format(
+      config.distributedDataType match {
+        case "rdd" => sc.cassandraTable[PerfRowClass](keyspace, table).count
+        case _ => read_columns(Seq("order_number", "qty", "color", "size", "order_time", "store"))
+      })
+    )
   }
 }
 
@@ -145,14 +160,17 @@ class FTSAllColumns(config: Config, ss: SparkSession) extends DatasetReadTask(co
  * Performs a full table scan and only retreives 5 of the columns for each row
  */
 class FTSFiveColumns(config: Config, ss: SparkSession) extends DatasetReadTask(config, ss) {
-  def run(): Unit = config.distributedDataType match {
-    case "rdd" =>
-      val count = sc.cassandraTable[(UUID, Int, String, String, org.joda.time.DateTime)](keyspace,
-        table)
-        .select("order_number", "qty", "color", "size", "order_time")
-        .count
-    case _ => val count = read_columns(Seq("order_number", "qty", "color", "size", "order_time"))
-    println(s"Loaded $count rows")
+  def run(): Unit = {
+    println("Loaded %d rows".format(
+      config.distributedDataType match {
+        case "rdd" =>
+          sc.cassandraTable[(UUID, Int, String, String, org.joda.time.DateTime)](keyspace,
+            table)
+            .select("order_number", "qty", "color", "size", "order_time")
+            .count
+        case _ => read_columns(Seq("order_number", "qty", "color", "size", "order_time"))
+      })
+    )
   }
 }
 

--- a/src/main/scala/com/datastax/sparkstress/ReadTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/ReadTask.scala
@@ -1,7 +1,7 @@
 package com.datastax.sparkstress
 
 import java.util.UUID
-
+import org.apache.spark.sql.SparkSession
 import com.datastax.spark.connector.cql.CassandraConnector
 import com.datastax.sparkstress.RowTypes.PerfRowClass
 import org.apache.spark.SparkContext
@@ -20,12 +20,23 @@ object ReadTask {
     "jwcpdclusteringallcolumns",
     "jwcrpallcolumns",
     "pdcount",
+    "ftsonecolumn_ds",
+    "ftstwocolumns_ds",
+    "ftsthreecolumns_ds",
+    "ftsfourcolumns_ds",
+    "ftsfivecolumns_ds",
+    "ftsallcolumns_ds",
+    "dsefsreadparquet_ds",
+    "dsefsreadtext_ds",
+    "dsefsreadjson_ds",
+    "dsefsreadcsv_ds",
     "retrievesinglepartition"
   )
 }
 
-abstract class ReadTask(config: Config, sc: SparkContext) extends StressTask {
+abstract class ReadTask(config: Config, ss: SparkSession) extends StressTask {
 
+  val sc = ss.sparkContext
   val uuidPivot = UUID.fromString("9b657ca1-bfb1-49c0-85f5-04b127adc6f3")
   val timePivot =  new DateTime(2000,1,1,0,0,0,0).plusSeconds(500)
   val keyspace = config.keyspace
@@ -39,7 +50,7 @@ abstract class ReadTask(config: Config, sc: SparkContext) extends StressTask {
   val coresPerNode:Int = defaultParallelism / numberNodes
   def run()
 
-  def runTrials(sc: SparkContext): Seq[TestResult] = {
+  def runTrials(ss: SparkSession): Seq[TestResult] = {
     println("About to Start Trials")
     for (trial <- 1 to config.trials) yield {
       TestResult(time(run()),0L)
@@ -48,18 +59,169 @@ abstract class ReadTask(config: Config, sc: SparkContext) extends StressTask {
 }
 
 /**
+  * Full Table Scan One Column using DataSets
+  * Performs a full table scan but only retrieves a single column from the underlying
+  * table.
+  */
+class FTSOneColumn_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    //val colorCounts = ss.read.cassandraFormat(table, keyspace).load().select("color").count
+    val count = ss.read
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> table, "keyspace" -> keyspace))
+      .load()
+      .select("color")
+      .count
+    println(s"Loaded $count rows")
+  }
+}
+
+/**
+  * Full Table Scan Two Columns using DataSets
+  * Performs a full table scan but only retrieves a single column from the underlying
+  * table.
+  */
+class FTSTwoColumns_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    val count = ss.read
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> table, keyspace -> "keyspace"))
+      .load()
+      .select("color", "size")
+      .count
+    println(s"Loaded $count rows")
+  }
+}
+
+/**
+  * Full Table Scan Three Columns using DataSets
+  * Performs a full table scan but only retrieves a single column from the underlying
+  * table.
+  */
+class FTSThreeColumns_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    val count = ss.read
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> table, keyspace -> "keyspace"))
+      .load()
+      .select("color", "size", "qty")
+      .count
+    println(s"Loaded $count rows")
+  }
+}
+
+/**
+  * Full Table Scan Four Columns using DataSets
+  * Performs a full table scan but only retrieves a single column from the underlying
+  * table.
+  */
+class FTSFourColumns_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    val count = ss.read
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> table, keyspace -> "keyspace"))
+      .load()
+      .select("color", "size", "qty", "order_number")
+      .count
+    println(s"Loaded $count rows")
+  }
+}
+
+/**
+  * Full Table Scan Five Columns using DataSets
+  * Performs a full table scan but only retrieves a single column from the underlying
+  * table.
+  */
+class FTSFiveColumns_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    val count = ss.read
+      .format("org.apache.spark.sql.cassandra")
+      .options(Map("table" -> table, keyspace -> "keyspace"))
+      .load()
+      .select("order_number", "qty", "color", "size", "order_time")
+      .count
+    println(s"Loaded $count rows")
+  }
+}
+
+/**
+  * Full Table Scan All Columns using DataSets
+  * Performs a full table scan but only retrieves a single column from the underlying
+  * table.
+  */
+class FTSAllColumns_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    val count = ss.read
+      .format ("org.apache.spark.sql.cassandra")
+      .options (Map ("table" -> table, keyspace -> "keyspace") )
+      .load()
+      .count
+    println(s"Loaded $count rows")
+  }
+}
+
+/**
+  * Read Parquet file from DSEFS using Datasets.
+  */
+class DSEFSReadParquet_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    val count = ss.read.parquet(s"dsefs:///${config.keyspace}.${config.table}").count
+    println(s"Loaded $count rows")
+  }
+}
+
+/**
+  * Read Text file from DSEFS using Datasets.
+  */
+class DSEFSReadText_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    val count = ss.read.text(s"dsefs:///${config.keyspace}.${config.table}").count
+    println(s"Loaded $count rows")
+  }
+}
+
+/**
+  * Read JSON file from DSEFS using Datasets.
+  */
+class DSEFSReadJson_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    val count = ss.read.json(s"dsefs:///${config.keyspace}.${config.table}").count
+    println(s"Loaded $count rows")
+  }
+}
+
+/**
+  * Read CSV file from DSEFS using Datasets.
+  */
+class DSEFSReadCsv_DS(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
+
+  def run(): Unit = {
+    val count = ss.read.csv(s"dsefs:///${config.keyspace}.${config.table}").count
+    println(s"Loaded $count rows")
+  }
+}
+/**
  * Push Down Count
  * Uses our internally cassandra count pushdown, this means all of the aggregation
  * is done on the C* side
  */
-class PDCount(config: Config, sc: SparkContext) extends ReadTask(config, sc) {
+class PDCount(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
 
   def run(): Unit = {
     val count = sc.cassandraTable(keyspace, table).cassandraCount()
     if (config.totalOps != count) {
       println(s"Read verification failed! Expected ${config.totalOps}, returned $count");
     }
-    println(count)
+    println(s"Loaded $count rows")
   }
 }
 
@@ -68,11 +230,11 @@ class PDCount(config: Config, sc: SparkContext) extends ReadTask(config, sc) {
  * Performs a full table scan but only retreives a single column from the underlying
  * table.
  */
-class FTSOneColumn(config: Config, sc: SparkContext) extends ReadTask(config, sc) {
+class FTSOneColumn(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
 
   def run(): Unit = {
-    val colorCounts = sc.cassandraTable[String](keyspace, table).select("color").count
-    println(colorCounts)
+    val count = sc.cassandraTable[String](keyspace, table).select("color").count
+    println(s"Loaded $count rows")
   }
 }
 
@@ -81,7 +243,7 @@ class FTSOneColumn(config: Config, sc: SparkContext) extends ReadTask(config, sc
  * Performs a full table scan but only retreives a single column from the underlying
  * table.
  */
-class FTSAllColumns(config: Config, sc: SparkContext) extends ReadTask(config, sc) {
+class FTSAllColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = {
     val count = sc.cassandraTable[PerfRowClass](keyspace, table).count
     println(s"Loaded $count rows")
@@ -92,7 +254,7 @@ class FTSAllColumns(config: Config, sc: SparkContext) extends ReadTask(config, s
  * Full Table Scan Five Columns
  * Performs a full table scan and only retreives 5 of the coulmns for each row
  */
-class FTSFiveColumns(config: Config, sc: SparkContext) extends ReadTask(config, sc) {
+class FTSFiveColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = {
     val count = sc.cassandraTable[(UUID, Int, String, String, org.joda.time.DateTime)](keyspace,
       table)
@@ -105,8 +267,8 @@ class FTSFiveColumns(config: Config, sc: SparkContext) extends ReadTask(config, 
 /**
  * Full Table Scan with a Clustering Column Predicate Pushed down to C*
  */
-class FTSPDClusteringAllColumns(config: Config, sc: SparkContext) extends ReadTask(config,
-  sc) {
+class FTSPDClusteringAllColumns(config: Config, ss: SparkSession) extends ReadTask(config,
+  ss) {
   def run(): Unit = {
     val count = sc.cassandraTable[PerfRowClass](keyspace, table)
       .where("order_time < ?", timePivot)
@@ -119,7 +281,7 @@ class FTSPDClusteringAllColumns(config: Config, sc: SparkContext) extends ReadTa
  * Full Table Scan with a Clustering Column Predicate Pushed down to C*
  * Only 5 columns retreived per row
  */
-class FTSPDClusteringFiveColumns(config: Config, sc: SparkContext) extends ReadTask(config, sc) {
+class FTSPDClusteringFiveColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = {
     val count = sc.cassandraTable[(UUID, Int, String, String, org.joda.time.DateTime)](keyspace,
       table)
@@ -133,7 +295,7 @@ class FTSPDClusteringFiveColumns(config: Config, sc: SparkContext) extends ReadT
 /**
  * Join With C* with 1M Partition Key requests
  */
-class JWCAllColumns(config: Config, sc: SparkContext) extends ReadTask(config, sc) {
+class JWCAllColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = {
     val count = sc.parallelize(1 to tenthKeys)
       .map(num => Tuple1(s"Store $num"))
@@ -147,8 +309,8 @@ class JWCAllColumns(config: Config, sc: SparkContext) extends ReadTask(config, s
  * Join With C* with 1M Partition Key requests
  * A repartitionByCassandraReplica occurs before retreiving the data
  */
-class JWCRPAllColumns(config: Config, sc: SparkContext) extends
-ReadTask(config, sc) {
+class JWCRPAllColumns(config: Config, ss: SparkSession) extends
+ReadTask(config, ss) {
   def run(): Unit = {
     val count = sc.parallelize(1 to tenthKeys)
       .map(num => Tuple1(s"Store $num"))
@@ -163,7 +325,7 @@ ReadTask(config, sc) {
  * Join With C* with 1M Partition Key requests
  * A clustering column predicate is pushed down to limit data retrevial
  */
-class JWCPDClusteringAllColumns(config: Config, sc: SparkContext) extends ReadTask(config, sc) {
+class JWCPDClusteringAllColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = {
     val count = sc.parallelize(1 to tenthKeys)
       .map(num => Tuple1(s"Store $num"))
@@ -177,7 +339,7 @@ class JWCPDClusteringAllColumns(config: Config, sc: SparkContext) extends ReadTa
 /**
  * A single C* partition is retreivied in an RDD
  */
-class RetrieveSinglePartition(config: Config, sc: SparkContext) extends ReadTask(config, sc) {
+class RetrieveSinglePartition(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   def run(): Unit = {
     val filterResults = sc.cassandraTable[String](keyspace, table)
       .where("store = ? ", "Store 5")

--- a/src/main/scala/com/datastax/sparkstress/RowTypes.scala
+++ b/src/main/scala/com/datastax/sparkstress/RowTypes.scala
@@ -1,7 +1,5 @@
 package com.datastax.sparkstress
 
-import java.util.UUID
-
 object RowTypes {
 
   sealed trait StressRow
@@ -12,8 +10,8 @@ object RowTypes {
 
   case class PerfRowClass(
    store: String,
-   order_time:org.joda.time.DateTime,
-   order_number:UUID,
+   order_time:String,   // org.joda.time.DateTime format
+   order_number:String, // java.util.UUID format
    color: String,
    size: String,
    qty: Int) extends StressRow

--- a/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
+++ b/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
@@ -113,7 +113,7 @@ object SparkCassandraStress {
       opt[Int]('z',"streamingBatchLength") optional() action { (arg,config) =>
         config.copy(streamingBatchIntervalSeconds = arg)
       } text {"Batch interval in seconds used for defining a StreamingContext."}
-      
+
       opt[Int]('m',"terminationTimeMinutes") optional() action { (arg,config) =>
         config.copy(terminationTimeMinutes = arg)
       } text { "The desired runtime (in minutes) for a given workload. WARNING: Not supported with multiple trials or read workloads."}
@@ -155,11 +155,13 @@ object SparkCassandraStress {
         .setAppName("SparkStress_"+config.testName)
         //Make sure for streaming that the keep_alive is sufficently large
         .set("spark.cassandra.connection.keep_alive_ms", (config.streamingBatchIntervalSeconds*1000*5).toString)
+        .set("spark.cassandra.input.metrics", "true")
+        .set("spark.cassandra.output.metrics", "true")
         .setAll(config.sparkOps)
 
     val sc = ConnectHelper.getContext(sparkConf)
-    
-    if (config.verboseOutput) { 
+
+    if (config.verboseOutput) {
       println("\nDumping debugging output")
       println(sc.getConf.toDebugString+"\n")
     }

--- a/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
+++ b/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
@@ -84,7 +84,8 @@ object SparkCassandraStress {
       } text {
         """See 'distributedDataType'.
           |                           rdd save methods:
-          |                           bulk: bulkSaveToCassandra, driver: saveToCassandra
+          |                             bulk: bulkSaveToCassandra
+          |                             driver: saveToCassandra
           |                           dataset save methods:
           |                             driver: ds.write.cassandraFormat(..).mode(..).save()
           |                             parquet: format to save in dsefs

--- a/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
+++ b/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
@@ -53,7 +53,7 @@ object SparkCassandraStress {
       head("SparkCassandraStress", "1.0")
 
       arg[String]("testName") optional() action { (arg,config) =>
-        config.copy(testName = arg)
+        config.copy(testName = arg.toLowerCase)
       } text {  s"""Tests :
               |Write Tests:  ${getWriteTestNames.mkString(" , ")}
               |Read Tests: ${getReadTestNames.mkString(" , ")}
@@ -196,15 +196,15 @@ object SparkCassandraStress {
   }
 
   def getReadTestNames(): Set[String] = {
-    getReadTests.map(_.getSimpleName)
+    getReadTests.map(_.getSimpleName.toLowerCase)
   }
 
   def getWriteTestNames(): Set[String] = {
-    getWriteTests.map(_.getSimpleName)
+    getWriteTests.map(_.getSimpleName.toLowerCase)
   }
 
   def getStreamingTestNames(): Set[String] = {
-    getStreamingTests.map(_.getSimpleName)
+    getStreamingTests.map(_.getSimpleName.toLowerCase)
   }
 
   def getValidTestNames(): Set[String] = {
@@ -213,7 +213,7 @@ object SparkCassandraStress {
 
   def getStressTest(config: Config, ss: SparkSession) : StressTask = {
     val subClasses = getValidTests.toList
-    val classMap = subClasses.map(_.getSimpleName).zip(subClasses).toMap
+    val classMap = subClasses.map(_.getSimpleName.toLowerCase).zip(subClasses).toMap
     classMap(config.testName)
       .getConstructors
       .maxBy(_.getParameterTypes.length)

--- a/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
+++ b/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
@@ -34,6 +34,7 @@ case class Config(
   receiverThroughputPerBatch: Long = 100000,
   terminationTimeMinutes: Long = 0,
   streamingBatchIntervalSeconds:  Int = 5,
+  distributedDataTypes: Seq[String] = Seq("rdd", "dataset"),
   rddSaveMethods: Seq[String] = Seq("driver", "bulk"),
   datasetSaveMethods: Seq[String] = Seq("driver", "parquet", "text", "json", "csv")
 )
@@ -162,10 +163,14 @@ object SparkCassandraStress {
         println("\nERROR: A termination time was specified with multiple trials, this is not supported yet.\n")
       } else if (getReadTestNames.contains(config.testName) && config.terminationTimeMinutes > 0) {
         println(s"\nERROR: A termination time was specified with '${config.testName} which is a Read test, this is not supported yet.\n")
+      } else if (!config.distributedDataTypes.contains(config.distributedDataType)) {
+        println(s"\nERROR: The distributedDataType (${config.distributedDataType}) provided is not valid. Use one of these distributed data types: "+config.distributedDataTypes.mkString(", ")+".\n")
+      } else if (!config.rddSaveMethods.contains(config.saveMethod) && !config.datasetSaveMethods.contains(config.saveMethod)) {
+        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid. Use one of these save methods: rdd: "+config.rddSaveMethods.mkString(", ")+", dataset: "+config.datasetSaveMethods.mkString(", ")+".\n")
       } else if (config.distributedDataType == "rdd" && !config.rddSaveMethods.contains(config.saveMethod)) {
-        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid with distributedDataType (${config.distributedDataType}). Use on of these: "+config.rddSaveMethods.mkString(", ")+".\n")
+        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid with distributedDataType (${config.distributedDataType}). Use one of these rdd save methods: "+config.rddSaveMethods.mkString(", ")+".\n")
       } else if (config.distributedDataType == "dataset" && !config.datasetSaveMethods.contains(config.saveMethod)) {
-        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid with distributedDataType (${config.distributedDataType}). Use on of these: "+config.datasetSaveMethods.mkString(", ")+".\n")
+        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid with distributedDataType (${config.distributedDataType}). Use one of these dataset save methods: "+config.datasetSaveMethods.mkString(", ")+".\n")
       }else {
         runTask(config)
       }

--- a/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
+++ b/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
@@ -1,7 +1,7 @@
 package com.datastax.sparkstress
 
 import java.io.{FileWriter, Writer}
-
+import java.lang.Math.round
 import org.apache.spark.SparkConf
 
 
@@ -22,6 +22,7 @@ case class Config(
   // csv file to append results
   file: Option[Writer] = Option.empty,
   saveMethod: String = "driver",
+  distributedDataType: String = "rdd",
   //Spark Options
   sparkOps: Map[String,String] = Map.empty,
   //Streaming Params
@@ -70,9 +71,13 @@ object SparkCassandraStress {
         config.copy(keyspace = arg)
       } text {"Name of the keyspace to use/create"}
 
+      opt[String]('e',"distributedDataType") optional() action { (arg,config) =>
+        config.copy(distributedDataType = arg)
+      } text {"See 'saveMethod'.\n\t\t\t   rdd: Resilient Distributed Dataset, the basic abstraction in Spark.\n\t\t\t   dataset: A DataSet is a strongly typed collection of domain-specific objects."}
+
       opt[String]('s',"saveMethod") optional() action { (arg,config) =>
         config.copy(saveMethod = arg)
-      } text {"rdd save method. bulk: bulkSaveToCassandra, driver: saveToCassandra"}
+      } text {"See 'distributedDataType'.\n\t\t\t   rdd save methods:\n\t\t\t     bulk: bulkSaveToCassandra, driver: saveToCassandra\n\t\t\t   dataset save methods:\n\t\t\t     driver: ds.write.cassandraFormat(..).mode(..).save()\n\t\t\t     parquet: format to save in dsefs\n\t\t\t     text: format to save in dsefs\n\t\t\t     json: format to save in dsefs\n\t\t\t     csv: format to save in dsefs"}
 
       opt[Int]('n',"trials")optional() action { (arg,config) =>
         config.copy(trials = arg)
@@ -157,61 +162,74 @@ object SparkCassandraStress {
         .set("spark.cassandra.connection.keep_alive_ms", (config.streamingBatchIntervalSeconds*1000*5).toString)
         .setAll(config.sparkOps)
 
-    val sc = ConnectHelper.getContext(sparkConf)
+    val ss = ConnectHelper.getSparkSession(sparkConf)
     
     if (config.verboseOutput) { 
       println("\nDumping debugging output")
-      println(sc.getConf.toDebugString+"\n")
+      println(ss.sparkContext.getConf.toDebugString+"\n")
     }
 
     val test: StressTask =
       config.testName.toLowerCase match {
           /** Write Tasks **/
-        case "writeshortrow" => new WriteShortRow(config, sc)
-        case "writewiderow" => new WriteWideRow(config, sc)
-        case "writeperfrow" => new WritePerfRow(config, sc)
-        case "writerandomwiderow" => new WriteRandomWideRow(config, sc)
-        case "writewiderowbypartition" => new WriteWideRowByPartition(config, sc)
+        case "writeshortrow" => new WriteShortRow(config, ss)
+        case "writewiderow" => new WriteWideRow(config, ss)
+        case "writeperfrow" => new WritePerfRow(config, ss)
+        case "writerandomwiderow" => new WriteRandomWideRow(config, ss)
+        case "writewiderowbypartition" => new WriteWideRowByPartition(config, ss)
 
-          /** Read Tasks **/
-        case "pdcount" => new PDCount(config, sc)
-        case "ftsallcolumns" => new FTSAllColumns(config, sc)
-        case "ftsfivecolumns" => new FTSFiveColumns(config, sc)
-        case "ftsonecolumn" => new FTSOneColumn(config, sc)
-        case "ftspdclusteringallcolumns" => new FTSPDClusteringAllColumns(config, sc)
-        case "ftspdclusteringfivecolumns" => new FTSPDClusteringFiveColumns(config, sc)
-        case "jwcallcolumns" => new JWCAllColumns(config, sc)
-        case "jwcpdclusteringallcolumns" => new JWCPDClusteringAllColumns(config, sc)
-        case "jwcrpallcolumns" => new JWCRPAllColumns(config, sc)
-        case "retrievesinglepartition" => new RetrieveSinglePartition(config, sc)
+          /** RDD Read Tasks **/
+        case "pdcount" => new PDCount(config, ss)
+        case "ftsallcolumns" => new FTSAllColumns(config, ss)
+        case "ftsfivecolumns" => new FTSFiveColumns(config, ss)
+        case "ftsonecolumn" => new FTSOneColumn(config, ss)
+        case "ftspdclusteringallcolumns" => new FTSPDClusteringAllColumns(config, ss)
+        case "ftspdclusteringfivecolumns" => new FTSPDClusteringFiveColumns(config, ss)
+        case "jwcallcolumns" => new JWCAllColumns(config, ss)
+        case "jwcpdclusteringallcolumns" => new JWCPDClusteringAllColumns(config, ss)
+        case "jwcrpallcolumns" => new JWCRPAllColumns(config, ss)
+        case "retrievesinglepartition" => new RetrieveSinglePartition(config, ss)
 
-          /** Streaming Tasks **/
-        case "streamingwrite" => new StreamingWrite(config, sc)
+          /** Dataset Read Tasks **/
+        case "ftsallcolumns_ds" => new FTSAllColumns_DS(config, ss)
+        case "ftsfivecolumns_ds" => new FTSFiveColumns_DS(config, ss)
+        case "ftsfourcolumns_ds" => new FTSFourColumns_DS(config, ss)
+        case "ftsthreecolumns_ds" => new FTSThreeColumns_DS(config, ss)
+        case "ftstwocolumns_ds" => new FTSTwoColumns_DS(config, ss)
+        case "ftsonecolumn_ds" => new FTSOneColumn_DS(config, ss)
+
+        case "dsefsreadparquet_ds" => new DSEFSReadParquet_DS(config, ss)
+        case "dsefsreadtext_ds" => new DSEFSReadText_DS(config, ss)
+        case "dsefsreadjson_ds" => new DSEFSReadJson_DS(config, ss)
+        case "dsefsreadcsv_ds" => new DSEFSReadCsv_DS(config, ss)
+
+        /** Streaming Tasks **/
+        case "streamingwrite" => new StreamingWrite(config, ss)
       }
 
     val wallClockStartTime = System.nanoTime()
 
-    val timesAndOps: Seq[TestResult]= test.runTrials(sc)
+    val timesAndOps: Seq[TestResult]= test.runTrials(ss)
     val time = for (x <- timesAndOps) yield {x.time}
     val totalCompletedOps = for (x <- timesAndOps) yield {x.ops}
 
     val wallClockStopTime = System.nanoTime() 
     val wallClockTimeDiff = wallClockStopTime - wallClockStartTime
     val wallClockTimeSeconds = (wallClockTimeDiff / 1000000000.0) 
-    val timeSeconds = time.map{ x => math.round( x / 1000000000.0 ) }
-    val opsPerSecond = for (i <- 0 to timeSeconds.size-1) yield {math.round(totalCompletedOps(i)/timeSeconds(i))}
+    val timeSeconds = time.map{ x => round( x / 1000000000.0 ) }
+    val opsPerSecond = for (i <- 0 to timeSeconds.size-1) yield {round((totalCompletedOps(i)).toDouble/timeSeconds(i))}
 
     test match {
       case x: WriteTask[_] =>  {
         println(s"TimeInSeconds : ${timeSeconds.mkString(",")}\n")
         println(s"OpsPerSecond : ${opsPerSecond.mkString(",")}\n")
         config.file.map(f => {f.write(csvResults(config, time));f.flush })
-        sc.stop()
+        ss.stop()
       }
       case x: ReadTask => {
         println(s"TimeInSeconds : ${timeSeconds.mkString(",")}\n")
         config.file.map(f => {f.write(csvResults(config, time));f.flush })
-        sc.stop()
+        ss.stop()
       }
       case y: StreamingTask[_] => {
         println("Streaming Begun")

--- a/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
+++ b/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
@@ -180,15 +180,15 @@ object SparkCassandraStress {
   }
 
   def getReadTests() = {
-    reflections.getSubTypesOf(classOf[ReadTask]).toSet
+    reflections.getTypesAnnotatedWith(classOf[ReadTest]).toSet
   }
 
   def getWriteTests() = {
-    reflections.getSubTypesOf(classOf[WriteTask[StressRow]]).toSet
+    reflections.getTypesAnnotatedWith(classOf[WriteTest]).toSet
   }
 
   def getStreamingTests() = {
-    reflections.getSubTypesOf(classOf[StreamingTask[StressRow]]).toSet
+    reflections.getTypesAnnotatedWith(classOf[StreamingTest]).toSet
   }
 
   def getValidTests() = {

--- a/src/main/scala/com/datastax/sparkstress/StreamingTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/StreamingTask.scala
@@ -13,12 +13,6 @@ import org.apache.spark.streaming.dstream.DStream
 import java.util.concurrent.TimeUnit
 import scala.reflect.ClassTag
 
-object StreamingTask {
-  val ValidTasks = Set(
-    "StreamingWrite"
-  )
-}
-
 abstract class StreamingTask[rowType](
   val config: Config,
   val ss: SparkSession)

--- a/src/main/scala/com/datastax/sparkstress/StreamingTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/StreamingTask.scala
@@ -84,6 +84,7 @@ abstract class StreamingTask[rowType](
   }
 }
 
+@StreamingTest
 class StreamingWrite(config: Config, ss: SparkSession) extends
   StreamingTask[PerfRowClass](config,ss)(implicitly[ClassTag[PerfRowClass]]){
 

--- a/src/main/scala/com/datastax/sparkstress/StreamingTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/StreamingTask.scala
@@ -15,7 +15,7 @@ import scala.reflect.ClassTag
 
 object StreamingTask {
   val ValidTasks = Set(
-    "streamingwrite"
+    "StreamingWrite"
   )
 }
 

--- a/src/main/scala/com/datastax/sparkstress/StressReceiver.scala
+++ b/src/main/scala/com/datastax/sparkstress/StressReceiver.scala
@@ -15,7 +15,7 @@ class StressReceiver[T](
 
   class EmitterThread(receiver: StressReceiver[_]) extends Thread(s"Emitter$index") {
     override def run(): Unit = {
-      val rowIterator = rowGenerator.generatePartition(index)
+      val rowIterator = rowGenerator.generatePartition(config.seed, index)
       val throughPutPerBlockInterval = (blockIntervalInMs / (config.streamingBatchIntervalSeconds * 1000.0) * config.receiverThroughputPerBatch).toLong
       while (rowIterator.hasNext) {
         val batchBegin = System.currentTimeMillis()

--- a/src/main/scala/com/datastax/sparkstress/StressTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/StressTask.scala
@@ -1,9 +1,9 @@
 package com.datastax.sparkstress
 
-import org.apache.spark.SparkContext
+import org.apache.spark.sql.SparkSession
 
 trait StressTask {
-    def runTrials(sc:SparkContext): Seq[TestResult]
+    def runTrials(ss:SparkSession): Seq[TestResult]
 
     def time(f: => Any): (Long) = {
       val t0 = System.nanoTime()

--- a/src/main/scala/com/datastax/sparkstress/WriteTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/WriteTask.scala
@@ -132,6 +132,7 @@ abstract class WriteTask[rowType](
  * Writes data to a schema which contains no clustering keys, no partitions will be
  * overwritten.
  */
+@WriteTest
 class WriteShortRow(config: Config, ss: SparkSession) extends
   WriteTask[ShortRowClass](config, ss)(implicitly[RowWriterFactory[ShortRowClass]]) {
 
@@ -157,6 +158,7 @@ class WriteShortRow(config: Config, ss: SparkSession) extends
 /**
  * Writes data in a format similar to the DataStax legacy 'tshirt' schema
  */
+@WriteTest
 class WritePerfRow(config: Config, ss: SparkSession) extends
   WriteTask[PerfRowClass](config, ss)(implicitly[RowWriterFactory[PerfRowClass]]) {
 
@@ -190,6 +192,7 @@ class WritePerfRow(config: Config, ss: SparkSession) extends
  * Runs inserts to partitions in a round robin fashion. This means partition key 1 will not
  * be written to twice until partition key n is written to once.
  */
+@WriteTest
 class WriteWideRow(config: Config, ss: SparkSession) extends
   WriteTask[WideRowClass](config, ss)(implicitly[RowWriterFactory[WideRowClass]]) {
 
@@ -219,6 +222,7 @@ class WriteWideRow(config: Config, ss: SparkSession) extends
  * Runs inserts to partitions in a random fashion. The chance that any particular partition
  * key will be written to at a time is 1/N. (flat distribution)
  */
+@WriteTest
 class WriteRandomWideRow(config: Config, ss: SparkSession) extends
   WriteTask[WideRowClass](config, ss)(implicitly[RowWriterFactory[WideRowClass]]) {
 
@@ -247,6 +251,7 @@ class WriteRandomWideRow(config: Config, ss: SparkSession) extends
  *  Runs inserts to partitions in an ordered fashion. All writes to partition 1 occur before any
  *  writes to partition 2.
  */
+@WriteTest
 class WriteWideRowByPartition(config: Config, ss: SparkSession) extends
   WriteTask[WideRowClass](config, ss)(implicitly[RowWriterFactory[WideRowClass]]) {
 

--- a/src/main/scala/com/datastax/sparkstress/WriteTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/WriteTask.scala
@@ -20,16 +20,6 @@ import org.apache.commons.io.IOUtils
 import scala.util.parsing.json.{JSON, JSONType, JSONArray, JSONObject}
 import java.net.URL
 
-object WriteTask {
-  val ValidTasks = Set(
-    "WriteShortRow",
-    "WritePerfRow",
-    "WriteWideRow",
-    "WriteRandomWideRow",
-    "WriteWideRowByPartition"
-  )
-}
-
 abstract class WriteTask[rowType](
   val config: Config,
   val ss: SparkSession)

--- a/src/main/scala/com/datastax/sparkstress/WriteTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/WriteTask.scala
@@ -22,11 +22,11 @@ import java.net.URL
 
 object WriteTask {
   val ValidTasks = Set(
-    "writeshortrow",
-    "writeperfrow",
-    "writewiderow",
-    "writerandomwiderow",
-    "writewiderowbypartition"
+    "WriteShortRow",
+    "WritePerfRow",
+    "WriteWideRow",
+    "WriteRandomWideRow",
+    "WriteWideRowByPartition"
   )
 }
 
@@ -64,8 +64,8 @@ abstract class WriteTask[rowType](
 
   def getDataset: org.apache.spark.sql.Dataset[rowType]
 
-  def save_dataset(saveMethod: String): Unit = {
-    saveMethod match {
+  def save_dataset(): Unit = {
+    config.saveMethod match {
       // filesystem save methods
       case "parquet" => getDataset.write.parquet(s"dsefs:///${config.keyspace}.${config.table}")
       case "text" => getDataset.map(row => row.toString()).write.text(s"dsefs:///${config.keyspace}.${config.table}") // requires a single column so we convert to a string
@@ -86,7 +86,6 @@ abstract class WriteTask[rowType](
    * @return a tuple containing (runtime, totalCompletedOps)
    */
   def run(): TestResult = {
-    import sqlContext.implicits._
     var totalCompletedOps: Long = 0L
     val runtime = time({
       val fs = Future {
@@ -98,7 +97,7 @@ abstract class WriteTask[rowType](
             }
           }
           case _ => {
-            save_dataset(config.saveMethod)
+            save_dataset()
           }
         }
       }

--- a/src/main/scala/com/datastax/sparkstress/WriteTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/WriteTask.scala
@@ -101,7 +101,6 @@ abstract class WriteTask[rowType](
             save_dataset(config.saveMethod)
           }
         }
-        //For Some reason the implicit doesn't work here in Connector 1.[1,0].X
       }
       try {
         if (config.terminationTimeMinutes > 0) {

--- a/src/main/scala/com/datastax/sparkstress/WriteTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/WriteTask.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 import java.util.concurrent.TimeoutException
 import scala.concurrent.{Await,Future}
 import scala.concurrent.ExecutionContext.Implicits.global
-
+import org.apache.spark.sql.cassandra._
 import org.apache.commons.io.IOUtils
 import scala.util.parsing.json.{JSON, JSONType, JSONArray, JSONObject}
 import java.net.URL
@@ -64,8 +64,7 @@ abstract class WriteTask[rowType](
       // regular save method to DSE/Cassandra
       case _ => getDataset
         .write
-        .format("org.apache.spark.sql.cassandra")
-        .options(Map("table" -> config.table, "keyspace" -> config.keyspace))
+        .cassandraFormat(config.table, config.keyspace)
         .mode("append")
         .save()
     }

--- a/src/main/scala/com/datastax/sparkstress/WriteTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/WriteTask.scala
@@ -153,11 +153,11 @@ class WriteShortRow(config: Config, ss: SparkSession) extends
          |${config.totalOps} Total Writes
          |${config.numPartitions} Num Partitions""".stripMargin
     )
-    RowGenerator.getShortRowRDD(ss, config.numPartitions, config.totalOps)
+    RowGenerator.getShortRowRDD(ss, config.seed, config.numPartitions, config.totalOps)
   }
 
   def getDataset: org.apache.spark.sql.Dataset[ShortRowClass] = {
-    RowGenerator.getShortRowDataset(ss, config.numPartitions, config.totalOps)
+    RowGenerator.getShortRowDataset(ss, config.seed, config.numPartitions, config.totalOps)
   }
 
 }
@@ -186,10 +186,10 @@ class WritePerfRow(config: Config, ss: SparkSession) extends
       else Seq.empty )
 
   def getRDD: RDD[PerfRowClass] =
-    RowGenerator.getPerfRowRdd(ss, config.numPartitions, config.totalOps, config.numTotalKeys)
+    RowGenerator.getPerfRowRdd(ss, config.seed, config.numPartitions, config.totalOps, config.numTotalKeys)
 
   def getDataset: org.apache.spark.sql.Dataset[PerfRowClass] = {
-    RowGenerator.getPerfRowDataset(ss, config.numPartitions, config.totalOps, config.numTotalKeys)
+    RowGenerator.getPerfRowDataset(ss, config.seed, config.numPartitions, config.totalOps, config.numTotalKeys)
   }
 
 }
@@ -214,11 +214,11 @@ class WriteWideRow(config: Config, ss: SparkSession) extends
          |${config.numTotalKeys} Cassandra Partitions""".stripMargin
     )
     RowGenerator
-      .getWideRowRdd(ss, config.numPartitions, config.totalOps, config.numTotalKeys)
+      .getWideRowRdd(ss, config.seed, config.numPartitions, config.totalOps, config.numTotalKeys)
   }
 
   def getDataset: org.apache.spark.sql.Dataset[WideRowClass] = {
-    RowGenerator.getWideRowDataset(ss, config.numPartitions, config.totalOps, config.numTotalKeys)
+    RowGenerator.getWideRowDataset(ss, config.seed, config.numPartitions, config.totalOps, config.numTotalKeys)
   }
 
 }
@@ -242,11 +242,11 @@ class WriteRandomWideRow(config: Config, ss: SparkSession) extends
          |${config.totalOps} Total Writes,
          |${config.numTotalKeys} Cassandra Partitions""".stripMargin
     )
-    RowGenerator.getRandomWideRow(ss, config.numPartitions, config.totalOps, config.numTotalKeys)
+    RowGenerator.getRandomWideRow(ss, config.seed, config.numPartitions, config.totalOps, config.numTotalKeys)
   }
 
   def getDataset: org.apache.spark.sql.Dataset[WideRowClass] = {
-    RowGenerator.getRandomWideRowDataset(ss, config.numPartitions, config.totalOps, config.numTotalKeys)
+    RowGenerator.getRandomWideRowDataset(ss, config.seed, config.numPartitions, config.totalOps, config.numTotalKeys)
   }
 
 }
@@ -270,11 +270,11 @@ class WriteWideRowByPartition(config: Config, ss: SparkSession) extends
          |${config.totalOps} Total Writes,
          |${config.numTotalKeys} Cassandra Partitions""".stripMargin
     )
-    RowGenerator.getWideRowByPartition(ss, config.numPartitions, config.totalOps, config.numTotalKeys)
+    RowGenerator.getWideRowByPartition(ss, config.seed, config.numPartitions, config.totalOps, config.numTotalKeys)
   }
 
   def getDataset: org.apache.spark.sql.Dataset[WideRowClass] = {
-    RowGenerator.getWideRowByPartitionDataset(ss, config.numPartitions, config.totalOps, config.numTotalKeys)
+    RowGenerator.getWideRowByPartitionDataset(ss, config.seed, config.numPartitions, config.totalOps, config.numTotalKeys)
   }
 
 }

--- a/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
@@ -36,49 +36,49 @@ class ReadTaskTests extends FlatSpec
            |REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 } """
           .stripMargin)}
 
-    val writer = new WritePerfRow(config, sc)
+    val writer = new WritePerfRow(config, ss)
     writer.setupCQL
     writer.run
   }
 
   "FTSOneColumn" should " be able to run" in {
-    new FTSOneColumn(config, sc).run
+    new FTSOneColumn(config, ss).run
   }
 
   "FTSAllColumns" should " be able to run" in {
-    new FTSAllColumns(config, sc).run
+    new FTSAllColumns(config, ss).run
   }
 
   "PDCount" should " be able to run" in {
-    new PDCount(config, sc).run
+    new PDCount(config, ss).run
   }
 
   "FTSFiveColumns" should " be able to run " in {
-    new FTSFiveColumns(config, sc).run
+    new FTSFiveColumns(config, ss).run
   }
 
   "FTSPDClusteringAllColumns" should " be able to run" in {
-    new FTSPDClusteringAllColumns(config, sc).run
+    new FTSPDClusteringAllColumns(config, ss).run
   }
 
   "FTSPDClusteringFiveColumns" should " be able to run" in {
-    new FTSPDClusteringFiveColumns(config, sc).run
+    new FTSPDClusteringFiveColumns(config, ss).run
   }
 
   "JWCAllColumns" should " be able to run" in {
-    new JWCAllColumns(config, sc).run
+    new JWCAllColumns(config, ss).run
   }
 
   "JWCRPAllColumns" should " be able to run " in {
-    new JWCRPAllColumns(config, sc).run
+    new JWCRPAllColumns(config, ss).run
   }
 
   "JWCPDClusteringAllColumns" should " be able to run " in {
-    new JWCPDClusteringAllColumns(config, sc).run
+    new JWCPDClusteringAllColumns(config, ss).run
   }
 
   "RetrieveSinglePartiton" should " be able to run " in {
-    new RetrieveSinglePartition(config,sc).run
+    new RetrieveSinglePartition(config,ss).run
   }
 
 

--- a/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
@@ -29,7 +29,11 @@ class ReadTaskTests extends FlatSpec
   val ss = ConnectHelper.getSparkSession(defaultSparkConf)
 
   override def beforeAll(): Unit = {
+    // Allow us to rerun tests with a clean slate
     val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))
+    conn.withSessionDo { session => session.execute(s"""DROP KEYSPACE IF EXISTS readperfks """)}
+    Thread.sleep(5000)
+
     conn.withSessionDo { session =>
       session.execute(
         s"""
@@ -82,6 +86,29 @@ class ReadTaskTests extends FlatSpec
     new RetrieveSinglePartition(config,ss).run
   }
 
+  // Dataset tests
+  "FTSOneColumn_DS" should " be able to run" in {
+    new FTSOneColumn_DS(config, ss).run
+  }
 
+  "FTSTwoColumns_DS" should " be able to run" in {
+    new FTSTwoColumns_DS(config, ss).run
+  }
+
+  "FTSThreeColumns_DS" should " be able to run" in {
+    new FTSThreeColumns_DS(config, ss).run
+  }
+
+  "FTSFourColumns_DS" should " be able to run" in {
+    new FTSFourColumns_DS(config, ss).run
+  }
+
+  "FTSFiveColumns_DS" should " be able to run" in {
+    new FTSFiveColumns_DS(config, ss).run
+  }
+
+  "FTSAllColumns_DS" should " be able to run" in {
+    new FTSAllColumns_DS(config, ss).run
+  }
 
 }

--- a/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
@@ -16,7 +16,6 @@ class ReadTaskTests extends FlatSpec
   with Matchers{
 
   def clearCache(): Unit = CassandraConnector.evictCache()
-
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
@@ -26,6 +25,8 @@ class ReadTaskTests extends FlatSpec
     numPartitions = 10,
     totalOps = 10000,
     numTotalKeys = 200)
+
+  val ss = ConnectHelper.getSparkSession(defaultSparkConf)
 
   override def beforeAll(): Unit = {
     val conn = CassandraConnector(Set(EmbeddedCassandra.getHost(0)))

--- a/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/ReadTaskTests/ReadTaskTests.scala
@@ -19,12 +19,21 @@ class ReadTaskTests extends FlatSpec
   useCassandraConfig(Seq("cassandra-default.yaml.template"))
   useSparkConf(defaultSparkConf)
 
-  val config = new Config(
+  val rdd_config = new Config(
     testName = "readperfks",
     keyspace = "readperfks",
     numPartitions = 10,
     totalOps = 10000,
-    numTotalKeys = 200)
+    numTotalKeys = 200,
+    distributedDataType = "rdd")
+
+  val dataset_config = new Config(
+    testName = "readperfks",
+    keyspace = "readperfks",
+    numPartitions = 10,
+    totalOps = 10000,
+    numTotalKeys = 200,
+    distributedDataType = "dataset")
 
   val ss = ConnectHelper.getSparkSession(defaultSparkConf)
 
@@ -41,74 +50,58 @@ class ReadTaskTests extends FlatSpec
            |REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 } """
           .stripMargin)}
 
-    val writer = new WritePerfRow(config, ss)
+    val writer = new WritePerfRow(rdd_config, ss)
     writer.setupCQL
     writer.run
   }
 
   "FTSOneColumn" should " be able to run" in {
-    new FTSOneColumn(config, ss).run
+    new FTSOneColumn(rdd_config, ss).run
+    new FTSOneColumn(dataset_config, ss).run
   }
 
   "FTSAllColumns" should " be able to run" in {
-    new FTSAllColumns(config, ss).run
+    new FTSAllColumns(rdd_config, ss).run
+    new FTSAllColumns(dataset_config, ss).run
   }
 
   "PDCount" should " be able to run" in {
-    new PDCount(config, ss).run
+    new PDCount(rdd_config, ss).run
+    new PDCount(dataset_config, ss).run
   }
 
   "FTSFiveColumns" should " be able to run " in {
-    new FTSFiveColumns(config, ss).run
+    new FTSFiveColumns(rdd_config, ss).run
+    new FTSFiveColumns(dataset_config, ss).run
   }
 
   "FTSPDClusteringAllColumns" should " be able to run" in {
-    new FTSPDClusteringAllColumns(config, ss).run
+    new FTSPDClusteringAllColumns(rdd_config, ss).run
+    new FTSPDClusteringAllColumns(dataset_config, ss).run
   }
 
   "FTSPDClusteringFiveColumns" should " be able to run" in {
-    new FTSPDClusteringFiveColumns(config, ss).run
+    new FTSPDClusteringFiveColumns(rdd_config, ss).run
+    new FTSPDClusteringFiveColumns(dataset_config, ss).run
   }
 
   "JWCAllColumns" should " be able to run" in {
-    new JWCAllColumns(config, ss).run
+    new JWCAllColumns(rdd_config, ss).run
+    new JWCAllColumns(dataset_config, ss).run
   }
 
   "JWCRPAllColumns" should " be able to run " in {
-    new JWCRPAllColumns(config, ss).run
+    new JWCRPAllColumns(rdd_config, ss).run
+    new JWCRPAllColumns(dataset_config, ss).run
   }
 
   "JWCPDClusteringAllColumns" should " be able to run " in {
-    new JWCPDClusteringAllColumns(config, ss).run
+    new JWCPDClusteringAllColumns(rdd_config, ss).run
+    new JWCPDClusteringAllColumns(dataset_config, ss).run
   }
 
   "RetrieveSinglePartiton" should " be able to run " in {
-    new RetrieveSinglePartition(config,ss).run
+    new RetrieveSinglePartition(rdd_config,ss).run
+    new RetrieveSinglePartition(dataset_config,ss).run
   }
-
-  // Dataset tests
-  "FTSOneColumn_DS" should " be able to run" in {
-    new FTSOneColumn_DS(config, ss).run
-  }
-
-  "FTSTwoColumns_DS" should " be able to run" in {
-    new FTSTwoColumns_DS(config, ss).run
-  }
-
-  "FTSThreeColumns_DS" should " be able to run" in {
-    new FTSThreeColumns_DS(config, ss).run
-  }
-
-  "FTSFourColumns_DS" should " be able to run" in {
-    new FTSFourColumns_DS(config, ss).run
-  }
-
-  "FTSFiveColumns_DS" should " be able to run" in {
-    new FTSFiveColumns_DS(config, ss).run
-  }
-
-  "FTSAllColumns_DS" should " be able to run" in {
-    new FTSAllColumns_DS(config, ss).run
-  }
-
 }

--- a/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
@@ -58,10 +58,11 @@ class WriteTaskTests extends FlatSpec
   val textTableName = "text_test"
   val jsonTableName = "json_test"
   val csvTableName = "csv_test"
-  dseFsClient.deleteRecursive(FilePath(s"/$parquetTableName"))
-  dseFsClient.deleteRecursive(FilePath(s"/test2.$textTableName"))
-  dseFsClient.deleteRecursive(FilePath(s"/test2.$jsonTableName"))
-  dseFsClient.deleteRecursive(FilePath(s"/test2.$csvTableName"))
+  val datasetTestKS = "test2"
+  dseFsClient.deleteRecursive(FilePath(s"/$datasetTestKS.$parquetTableName"))
+  dseFsClient.deleteRecursive(FilePath(s"/$datasetTestKS.$textTableName"))
+  dseFsClient.deleteRecursive(FilePath(s"/$datasetTestKS.$jsonTableName"))
+  dseFsClient.deleteRecursive(FilePath(s"/$datasetTestKS.$csvTableName"))
 
   val ss = ConnectHelper.getSparkSession(sparkConf)
 
@@ -161,7 +162,7 @@ class WriteTaskTests extends FlatSpec
   it should " save to C* using Dataset API" in {
     val config = new Config(
       testName = "WritePerfRow_DS_Cass",
-      keyspace = "test2",
+      keyspace = datasetTestKS,
       numPartitions = 10,
       totalOps = 1000,
       numTotalKeys = 200,
@@ -176,7 +177,7 @@ class WriteTaskTests extends FlatSpec
   it should " save to DSEFS using parquet format" in {
     val config = new Config(
       testName = "WritePerfRow_Parquet",
-      keyspace = "test2",
+      keyspace = datasetTestKS,
       table = parquetTableName,
       numPartitions = 10,
       totalOps = 1000,
@@ -191,7 +192,7 @@ class WriteTaskTests extends FlatSpec
   it should " save to DSEFS using text format" in {
     val config = new Config(
       testName = "WritePerfRow_Text",
-      keyspace = "test2",
+      keyspace = datasetTestKS,
       table = textTableName,
       numPartitions = 10,
       totalOps = 1000,
@@ -206,7 +207,7 @@ class WriteTaskTests extends FlatSpec
   it should " save to DSEFS using json format" in {
     val config = new Config(
       testName = "WritePerfRow_JSON",
-      keyspace = "test2",
+      keyspace = datasetTestKS,
       table = jsonTableName,
       numPartitions = 10,
       totalOps = 1000,
@@ -221,7 +222,7 @@ class WriteTaskTests extends FlatSpec
   it should " save to DSEFS using csv format" in {
     val config = new Config(
       testName = "WritePerfRow_CSV",
-      keyspace = "test2",
+      keyspace = datasetTestKS,
       table = csvTableName,
       numPartitions = 10,
       totalOps = 1000,

--- a/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
@@ -32,7 +32,7 @@ class WriteTaskTests extends FlatSpec
 
   "The RDD" should "have the correct configurations" in {
     val config = new Config(keyspace = "test1", numPartitions = 1, totalOps = 20, numTotalKeys = 1)
-    val writer = new WriteShortRow(config, sc)
+    val writer = new WriteShortRow(config, ss)
     val rdd = writer.getRDD
     rdd.partitions.length should be (config.numPartitions)
     rdd.count should be (config.totalOps)
@@ -40,10 +40,10 @@ class WriteTaskTests extends FlatSpec
 
  "WriteShortRow" should "save correctly" in {
     val config = new Config(keyspace = "test3", numPartitions = 1, totalOps = 6, numTotalKeys = 1)
-    val writer = new WriteShortRow(config, sc)
+    val writer = new WriteShortRow(config, ss)
     writer.setupCQL
     writer.run
-    sc.cassandraTable(config.keyspace,config.table).count should be (6)
+    ss.sparkContext.cassandraTable(config.keyspace,config.table).count should be (6)
   }
 
   "WriteWideRow" should "save correctly" in {
@@ -53,10 +53,10 @@ class WriteTaskTests extends FlatSpec
       numPartitions = 1, 
       totalOps = 8, 
       numTotalKeys = 1)
-    val writer = new WriteWideRow(config, sc)
+    val writer = new WriteWideRow(config, ss)
     writer.setupCQL
     writer.run
-    sc.cassandraTable(config.keyspace,config.table).count should be (8)
+    ss.sparkContext.cassandraTable(config.keyspace,config.table).count should be (8)
   }
 
   "WriteRandomWideRow" should "save correctly" in {
@@ -66,10 +66,10 @@ class WriteTaskTests extends FlatSpec
       numPartitions = 10, 
       totalOps = 20, 
       numTotalKeys = 1)
-    val writer = new WriteRandomWideRow(config, sc)
+    val writer = new WriteRandomWideRow(config, ss)
     writer.setupCQL
     writer.run
-    sc.cassandraTable(config.keyspace,config.table).count should be (20)
+    ss.sparkContext.cassandraTable(config.keyspace,config.table).count should be (20)
   }
 
   "WriteWideRowByPartition" should "save correctly" in {
@@ -79,10 +79,10 @@ class WriteTaskTests extends FlatSpec
       numPartitions = 1, 
       totalOps = 40, 
       numTotalKeys = 5)
-    val writer = new WriteWideRowByPartition(config, sc)
+    val writer = new WriteWideRowByPartition(config, ss)
     writer.setupCQL
     writer.run
-    sc.cassandraTable(config.keyspace,config.table).count should be (40)
+    ss.sparkContext.cassandraTable(config.keyspace,config.table).count should be (40)
   }
 
   "WritePerfRow" should " generate the correct number of pks" in {
@@ -92,7 +92,7 @@ class WriteTaskTests extends FlatSpec
       numPartitions = 5,
       totalOps = 1000,
       numTotalKeys = 200)
-    val writer = new WritePerfRow(config, sc)
+    val writer = new WritePerfRow(config, ss)
     val results = writer.getRDD.map(_.store).countByValue()
     results should have size (200)
   }
@@ -104,7 +104,7 @@ class WriteTaskTests extends FlatSpec
       numPartitions = 2,
       totalOps = 40,
       numTotalKeys = 4)
-    val writer = new WritePerfRow(config, sc)
+    val writer = new WritePerfRow(config, ss)
     val rowLengths = writer.getRDD.groupBy( u=> u.store).map(row => row._2).collect
     for (row <- rowLengths)
       row should have size 10
@@ -117,10 +117,10 @@ class WriteTaskTests extends FlatSpec
       numPartitions = 10,
       totalOps = 1000,
       numTotalKeys = 200)
-    val writer = new WritePerfRow(config, sc)
+    val writer = new WritePerfRow(config, ss)
     writer.setupCQL
     writer.run
-    sc.cassandraTable(config.keyspace, config.table).count should be (1000)
+    ss.sparkContext.cassandraTable(config.keyspace, config.table).count should be (1000)
   }
 
 }

--- a/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
@@ -30,6 +30,8 @@ class WriteTaskTests extends FlatSpec
     session.execute(s"""CREATE KEYSPACE IF NOT EXISTS test7 WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 } """)
   }
 
+  val ss = ConnectHelper.getSparkSession(defaultSparkConf)
+
   "The RDD" should "have the correct configurations" in {
     val config = new Config(keyspace = "test1", numPartitions = 1, totalOps = 20, numTotalKeys = 1)
     val writer = new WriteShortRow(config, ss)

--- a/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
+++ b/src/test/scala/com/datastax/sparkstress/WriteTaskTests/WriteTaskTests.scala
@@ -8,6 +8,9 @@ import org.scalatest.junit.JUnitRunner
 import org.junit.runner.RunWith
 import com.datastax.sparkstress._
 import org.apache.spark.SparkConf
+import com.datastax.bdp.fs.client.{DseFsClient,DseFsClientConf}
+import com.datastax.bdp.fs.model.HostAndPort
+import com.datastax.bdp.fs.model.FilePath
 
 @RunWith(classOf[JUnitRunner])
 class WriteTaskTests extends FlatSpec
@@ -48,6 +51,17 @@ class WriteTaskTests extends FlatSpec
     session.execute(s"""CREATE KEYSPACE test6 WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 } """)
     session.execute(s"""CREATE KEYSPACE test7 WITH REPLICATION = { 'class': 'SimpleStrategy', 'replication_factor': 1 } """)
   }
+
+  // Wipe content from DSEFS too
+  val dseFsClient = new DseFsClient(new DseFsClientConf(Seq(HostAndPort.defaultPublicDseFsEndpoint("localhost"))))
+  val parquetTableName = "parquet_test"
+  val textTableName = "text_test"
+  val jsonTableName = "json_test"
+  val csvTableName = "csv_test"
+  dseFsClient.deleteRecursive(FilePath(s"/$parquetTableName"))
+  dseFsClient.deleteRecursive(FilePath(s"/test2.$textTableName"))
+  dseFsClient.deleteRecursive(FilePath(s"/test2.$jsonTableName"))
+  dseFsClient.deleteRecursive(FilePath(s"/test2.$csvTableName"))
 
   val ss = ConnectHelper.getSparkSession(sparkConf)
 
@@ -163,7 +177,7 @@ class WriteTaskTests extends FlatSpec
     val config = new Config(
       testName = "WritePerfRow_Parquet",
       keyspace = "test2",
-      table = "parquet_test",
+      table = parquetTableName,
       numPartitions = 10,
       totalOps = 1000,
       numTotalKeys = 200,
@@ -178,7 +192,7 @@ class WriteTaskTests extends FlatSpec
     val config = new Config(
       testName = "WritePerfRow_Text",
       keyspace = "test2",
-      table = "text_test",
+      table = textTableName,
       numPartitions = 10,
       totalOps = 1000,
       numTotalKeys = 200,
@@ -193,7 +207,7 @@ class WriteTaskTests extends FlatSpec
     val config = new Config(
       testName = "WritePerfRow_JSON",
       keyspace = "test2",
-      table = "json_test",
+      table = jsonTableName,
       numPartitions = 10,
       totalOps = 1000,
       numTotalKeys = 200,
@@ -208,7 +222,7 @@ class WriteTaskTests extends FlatSpec
     val config = new Config(
       testName = "WritePerfRow_CSV",
       keyspace = "test2",
-      table = "csv_test",
+      table = csvTableName,
       numPartitions = 10,
       totalOps = 1000,
       numTotalKeys = 200,


### PR DESCRIPTION
Goal: Add support for reads/writes using the Dataset API, also add support for reads/writes with DSEFS.

Example writing 1M rows to a parquet file in DSEFS: 
```./run.sh dse -e dataset -s parquet -t parquet -o 1000000 writeperfrow```

Example reading 1M rows from a parquet file in DSEFS: 
```./run.sh dse -e dataset -t parquet -o 1000000 dsefsreadparquet_ds```