### PR TITLE
DSP-14028: Generalize reference to spark connector.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,9 +14,9 @@ ext.mainClassName = "com.datastax.sparkstress.SparkCassandraStress"
 
 def determineConnectorVersion() {
     if (against == 'dse') {
-        def connector = fileTree(dir: "$DseResources/spark/lib", include: 'spark*connector*_*.jar')
+        def connector = fileTree(dir: "$DseResources/spark/lib", include: 'spark*connector*jar')
         def connectorJarName = (connector as List)[0].name
-        def match = connectorJarName =~ /connector.*_.*-(\d+\.\d+.\d+).*\.jar/
+        def match = connectorJarName =~ /.*(\d+\.\d+.\d+).*jar/
         assert match.find(), "Unable to find Spark Cassandra Connector"
         assert match.group(1).length() != 0, "Unable to determine version from " + match.group(0)
         println("Connector Version = " + match.group(1))


### PR DESCRIPTION
This generalizes the reference to the spark connector jar. With this fix we can build spark-stress now with DSE 6.0.0.

The real fix we need is to use the version from the manifest (e.g. 6.0.0-master), but those artifacts are currently unavailable so we'll push that change to a follow-up PR. See DSP-14028 for the on going discussion.