### PR TITLE
Avoid blocking on secure random for new uuids

### DIFF
--- a/src/main/scala/com/datastax/sparkstress/DataGenerator.scala
+++ b/src/main/scala/com/datastax/sparkstress/DataGenerator.scala
@@ -137,7 +137,7 @@ object RowGenerator {
         val size = sizes(r.nextInt(sizes.size))
         val qty = qtys(r.nextInt(qtys.size))
         val store = s"Store ${pk + offset}"
-        val order_number = UUID.randomUUID().toString()
+        val order_number = new UUID(pk,ck).toString
         val order_time = new Timestamp(perftime.plusSeconds(r.nextInt(1000)).getMillis)
         PerfRowClass(store, order_time, order_number, color, size, qty)
       }


### PR DESCRIPTION
UUIDS are now generated deterministically based on the
row they appear in.