### PR TITLE
Fix reference checking to saveMethod and distributedDataType.

### DIFF
--- a/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
+++ b/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
@@ -46,10 +46,7 @@ case class Config(
   numReceivers: Int = 1,
   receiverThroughputPerBatch: Long = 100000,
   terminationTimeMinutes: Long = 0,
-  streamingBatchIntervalSeconds:  Int = 5,
-  distributedDataTypes: Seq[DistributedDataType.Value] = Seq(DistributedDataType.RDD, DistributedDataType.DataFrame),
-  rddSaveMethods: Seq[SaveMethod.Value] = Seq(SaveMethod.Driver, SaveMethod.Bulk),
-  dataframeSaveMethods: Seq[SaveMethod.Value] = Seq(SaveMethod.Driver, SaveMethod.Parquet, SaveMethod.Json, SaveMethod.Csv, SaveMethod.Text)
+  streamingBatchIntervalSeconds:  Int = 5
 )
 
 case class TestResult ( time: Long, ops: Long )
@@ -176,14 +173,6 @@ object SparkCassandraStress {
         println("\nERROR: A termination time was specified with multiple trials, this is not supported yet.\n")
       } else if (getReadTestNames.contains(config.testName) && config.terminationTimeMinutes > 0) {
         println(s"\nERROR: A termination time was specified with '${config.testName} which is a Read test, this is not supported yet.\n")
-      } else if (!config.distributedDataTypes.contains(config.distributedDataType)) {
-        println(s"\nERROR: The distributedDataType (${config.distributedDataType}) provided is not valid. Use one of these distributed data types: "+config.distributedDataTypes.mkString(", ")+".\n")
-      } else if (!config.rddSaveMethods.contains(config.saveMethod) && !config.dataframeSaveMethods.contains(config.saveMethod)) {
-        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid. Use one of these save methods: rdd: "+config.rddSaveMethods.mkString(", ")+", dataset: "+config.dataframeSaveMethods.mkString(", ")+".\n")
-      } else if (config.distributedDataType == "rdd" && !config.rddSaveMethods.contains(config.saveMethod)) {
-        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid with distributedDataType (${config.distributedDataType}). Use one of these rdd save methods: "+config.rddSaveMethods.mkString(", ")+".\n")
-      } else if (config.distributedDataType == "dataset" && !config.dataframeSaveMethods.contains(config.saveMethod)) {
-        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid with distributedDataType (${config.distributedDataType}). Use one of these dataset save methods: "+config.dataframeSaveMethods.mkString(", ")+".\n")
       }else {
         runTask(config)
       }

--- a/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
+++ b/src/main/scala/com/datastax/sparkstress/SparkCassandraStress.scala
@@ -47,9 +47,9 @@ case class Config(
   receiverThroughputPerBatch: Long = 100000,
   terminationTimeMinutes: Long = 0,
   streamingBatchIntervalSeconds:  Int = 5,
-  distributedDataTypes: Seq[String] = Seq("rdd", "dataset"),
-  rddSaveMethods: Seq[String] = Seq("driver", "bulk"),
-  datasetSaveMethods: Seq[String] = Seq("driver", "parquet", "text", "json", "csv")
+  distributedDataTypes: Seq[DistributedDataType.Value] = Seq(DistributedDataType.RDD, DistributedDataType.DataFrame),
+  rddSaveMethods: Seq[SaveMethod.Value] = Seq(SaveMethod.Driver, SaveMethod.Bulk),
+  dataframeSaveMethods: Seq[SaveMethod.Value] = Seq(SaveMethod.Driver, SaveMethod.Parquet, SaveMethod.Json, SaveMethod.Csv, SaveMethod.Text)
 )
 
 case class TestResult ( time: Long, ops: Long )
@@ -178,12 +178,12 @@ object SparkCassandraStress {
         println(s"\nERROR: A termination time was specified with '${config.testName} which is a Read test, this is not supported yet.\n")
       } else if (!config.distributedDataTypes.contains(config.distributedDataType)) {
         println(s"\nERROR: The distributedDataType (${config.distributedDataType}) provided is not valid. Use one of these distributed data types: "+config.distributedDataTypes.mkString(", ")+".\n")
-      } else if (!config.rddSaveMethods.contains(config.saveMethod) && !config.datasetSaveMethods.contains(config.saveMethod)) {
-        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid. Use one of these save methods: rdd: "+config.rddSaveMethods.mkString(", ")+", dataset: "+config.datasetSaveMethods.mkString(", ")+".\n")
+      } else if (!config.rddSaveMethods.contains(config.saveMethod) && !config.dataframeSaveMethods.contains(config.saveMethod)) {
+        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid. Use one of these save methods: rdd: "+config.rddSaveMethods.mkString(", ")+", dataset: "+config.dataframeSaveMethods.mkString(", ")+".\n")
       } else if (config.distributedDataType == "rdd" && !config.rddSaveMethods.contains(config.saveMethod)) {
         println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid with distributedDataType (${config.distributedDataType}). Use one of these rdd save methods: "+config.rddSaveMethods.mkString(", ")+".\n")
-      } else if (config.distributedDataType == "dataset" && !config.datasetSaveMethods.contains(config.saveMethod)) {
-        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid with distributedDataType (${config.distributedDataType}). Use one of these dataset save methods: "+config.datasetSaveMethods.mkString(", ")+".\n")
+      } else if (config.distributedDataType == "dataset" && !config.dataframeSaveMethods.contains(config.saveMethod)) {
+        println(s"\nERROR: The saveMethod (${config.saveMethod}) provided is not valid with distributedDataType (${config.distributedDataType}). Use one of these dataset save methods: "+config.dataframeSaveMethods.mkString(", ")+".\n")
       }else {
         runTask(config)
       }

--- a/src/main/scala/com/datastax/sparkstress/WriteTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/WriteTask.scala
@@ -117,7 +117,7 @@ abstract class WriteTask[rowType](
   def runTrials(ss: SparkSession): Seq[TestResult] = {
     println("About to Start Trials")
     for (trial <- 1 to config.trials) yield {
-      if (config.saveMethod == "driver" || config.saveMethod == "bulk") setupCQL()
+      if (config.saveMethod == SaveMethod.Driver || config.saveMethod == SaveMethod.Bulk) setupCQL()
       Thread.sleep(10000)
       run()
     }


### PR DESCRIPTION
SparkCassandraStress.scala was patched to fix this:
```
$ ./run.sh dse -v -o 10000000 -t tab3 writeperfrow

ERROR: The distributedDataType (rdd) provided is not valid. Use one of these distributed data types: rdd, dataset.
```

WriteTask.scala patch was needed so that we create the keyspace/table.