### PR TITLE
Removes Private Spark Access for Compatibility

### DIFF
--- a/src/main/scala/org/apache/spark/ExposeJobListener.scala
+++ b/src/main/scala/org/apache/spark/ExposeJobListener.scala
@@ -1,9 +1,0 @@
-package org.apache.spark
-import org.apache.spark.ui.jobs.JobProgressListener
-
-object ExposeJobListener {
-  def getjobListener(sparkContext: SparkContext): JobProgressListener = {
-    sparkContext.jobProgressListener
-  }
-}
-


### PR DESCRIPTION
Previously the code used an private Spark API for determining the number
of records which were written in fail conditions. This API was
deprecated and removed so instead we use the public api to estimate the
number of records written.