### PR TITLE
Lower the version of Reflection Lib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -136,7 +136,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.12'
     testCompile "org.scala-lang:scala-library:$scalaVersion"
     testCompile "org.scalatest:scalatest_$ScalaVersionShort:2.2.4"
-    compile("org.reflections:reflections:0.9.11") {
+    compile("org.reflections:reflections:0.9.9") {
         exclude group: 'dom4j', module: 'dom4j'
         exclude group: 'org.javassist', module: 'javassist'
     }


### PR DESCRIPTION
The version currently included has a guava 20.0 dependency which
conflicts with OSS Spark. Moving it back to .9 moves the guava dep back
to one which is compatibile with Spark.