### PR TITLE
Change Perfrow usage of Insant to j.u.Date

### DIFF
--- a/src/main/scala/com/datastax/sparkstress/ReadTask.scala
+++ b/src/main/scala/com/datastax/sparkstress/ReadTask.scala
@@ -165,7 +165,7 @@ class FTSFiveColumns(config: Config, ss: SparkSession) extends ReadTask(config, 
   override def performTask(): Long = {
     config.distributedDataType match {
       case RDD =>
-        sc.cassandraTable[(UUID, Int, String, String, Instant)](keyspace,
+        sc.cassandraTable[(UUID, Int, String, String, java.util.Date)](keyspace,
           table)
           .select("order_number", "qty", "color", "size", "order_time")
           .count
@@ -202,7 +202,7 @@ class FTSPDClusteringAllColumns(config: Config, ss: SparkSession) extends ReadTa
 class FTSPDClusteringFiveColumns(config: Config, ss: SparkSession) extends ReadTask(config, ss) {
   override def performTask(): Long = config.distributedDataType match {
       case RDD =>
-        sc.cassandraTable[(UUID, Int, String, String, Instant)](keyspace, table)
+        sc.cassandraTable[(UUID, Int, String, String, java.util.Date)](keyspace, table)
           .where("order_time < ?", timePivot)
           .select("order_number", "qty", "color", "size", "order_time")
           .count

--- a/src/main/scala/com/datastax/sparkstress/RowGenerator.scala
+++ b/src/main/scala/com/datastax/sparkstress/RowGenerator.scala
@@ -134,7 +134,7 @@ object RowGenerator {
         val qty = qtys(r.nextInt(qtys.size))
         val store = s"Store ${pk + offset}"
         val order_number = new UUID(pk,ck)
-        val order_time = perftime.plusSeconds(r.nextInt(1000))
+        val order_time = java.util.Date.from(perftime.plusSeconds(r.nextInt(1000)))
         PerfRowClass(store, order_time, order_number, color, size, qty)
       }
     }
@@ -151,10 +151,8 @@ object RowGenerator {
 
   def getPerfRowDataFrame(ss: SparkSession, seed: Long, numPartitions: Int, numTotalRows: Long, numTotalKeys: Long): DataFrame = {
     import ss.implicits._
-    // There exists no encoder for Joda DateTimeObjects so let's build a tuple that the encoders can handle
-    getPerfRowRdd(ss, seed, numPartitions, numTotalRows, numTotalKeys).mapPartitions(
-      it => it.map( p => (p.store, instantToTimestamp(p.order_time), p.order_number.toString, p.color, p.size, p.qty))
-    ).toDF("store", "order_time", "order_number", "color", "size", "qty")
+    getPerfRowRdd(ss, seed, numPartitions, numTotalRows, numTotalKeys)
+      .toDF
   }
 
   def instantToTimestamp(instant: Instant): Timestamp = {

--- a/src/main/scala/com/datastax/sparkstress/RowTypes.scala
+++ b/src/main/scala/com/datastax/sparkstress/RowTypes.scala
@@ -12,7 +12,7 @@ object RowTypes {
 
   case class PerfRowClass(
     store: String,
-    order_time: java.time.Instant,
+    order_time: java.util.Date,
     order_number: UUID,
     color: String,
     size: String,


### PR DESCRIPTION
Older version of the SCC cannot handle a conversion from
java.util.Date (Driver native codec for timestamp columns) to
java.time.Insant. This means SCS doesn't work with older versions of DSE
or the SCC made before 3.0.

To fix this we switch to java.util.Date instead of instant